### PR TITLE
Add scale-in cooldown support

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"time"
 
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 	"github.com/buildkite/buildkite-agent-scaler/scaler"
@@ -19,6 +20,9 @@ func main() {
 		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
 		buildkiteAgentToken = flag.String("agent-token", "", "A buildkite agent registration token")
 
+		// scale in params
+		scaleInAdjustment = flag.Int64("scale-in-adjustment", -1, "Maximum adjustment to the desired capacity on scale in")
+
 		// general params
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
 	)
@@ -32,6 +36,12 @@ func main() {
 		AgentsPerInstance:        *agentsPerInstance,
 		PublishCloudWatchMetrics: *cwMetrics,
 		DryRun:                   *dryRun,
+		ScaleInParams: scaler.ScaleInParams{
+			// We run in one-shot so cooldown isn't implemented
+			CooldownPeriod:  time.Duration(0),
+			Adjustment:      *scaleInAdjustment,
+			LastScaleInTime: &time.Time{},
+		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -2,9 +2,10 @@ package scaler
 
 import (
 	"testing"
+	"time"
 )
 
-func TestScalingWithoutError(t *testing.T) {
+func TestScalingOutWithoutError(t *testing.T) {
 	for _, tc := range []struct {
 		ScheduledJobs     int64
 		AgentsPerInstance int
@@ -37,6 +38,71 @@ func TestScalingWithoutError(t *testing.T) {
 	}
 }
 
+func TestScalingInWithoutError(t *testing.T) {
+	testCases := []struct {
+		currentDesiredCapacity int64
+		coolDownPeriod         time.Duration
+		lastScaleInTime        time.Time
+		adjustment             int64
+
+		expectedDesiredCapacity int64
+	}{
+		{
+			currentDesiredCapacity: 10,
+			coolDownPeriod:         5 * time.Minute,
+			lastScaleInTime:        time.Now(),
+			adjustment:             -1,
+
+			// We're inside cooldown
+			expectedDesiredCapacity: 10,
+		},
+		{
+			currentDesiredCapacity: 10,
+			coolDownPeriod:         5 * time.Minute,
+			lastScaleInTime:        time.Now().Add(-10 * time.Minute),
+			adjustment:             -2,
+
+			// We're out of cooldown but we can only adjust by -2
+			expectedDesiredCapacity: 8,
+		},
+		{
+			currentDesiredCapacity: 10,
+			coolDownPeriod:         5 * time.Minute,
+			lastScaleInTime:        time.Now().Add(-10 * time.Minute),
+			adjustment:             -100,
+
+			// We're allowed to adjust the whole amount
+			expectedDesiredCapacity: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			asg := &asgTestDriver{desiredCapacity: tc.currentDesiredCapacity}
+			s := Scaler{
+				autoscaling:       asg,
+				bk:                &buildkiteTestDriver{count: 0},
+				agentsPerInstance: 1,
+				scaleInParams: ScaleInParams{
+					CooldownPeriod:  tc.coolDownPeriod,
+					Adjustment:      tc.adjustment,
+					LastScaleInTime: &tc.lastScaleInTime,
+				},
+			}
+
+			if err := s.Run(); err != nil {
+				t.Fatal(err)
+			}
+
+			if asg.desiredCapacity != tc.expectedDesiredCapacity {
+				t.Fatalf("Expected desired capacity of %d, got %d",
+					tc.expectedDesiredCapacity, asg.desiredCapacity,
+				)
+			}
+		})
+	}
+}
+
 type buildkiteTestDriver struct {
 	count int64
 	err   error
@@ -52,7 +118,11 @@ type asgTestDriver struct {
 }
 
 func (d *asgTestDriver) Describe() (AutoscaleGroupDetails, error) {
-	return AutoscaleGroupDetails{MinSize: 0, MaxSize: 100}, nil
+	return AutoscaleGroupDetails{
+		DesiredCount: d.desiredCapacity,
+		MinSize:      0,
+		MaxSize:      100,
+	}, nil
 }
 
 func (d *asgTestDriver) SetDesiredCapacity(count int64) error {

--- a/template.yaml
+++ b/template.yaml
@@ -19,6 +19,17 @@ Parameters:
     Type: String
     Default: default
 
+  ScaleInCooldownPeriod:
+    Description: Cooldown period between scale in events
+    Type: String
+    Default: 5m
+
+  ScaleInAdjustment:
+    Description: Maximum adjustment to the desired capacity on scale in
+    Type: Number
+    MaxValue: -1
+    Default: -1
+
 Mappings:
   LambdaBucket:
     us-east-1 : { Bucket: "buildkite-lambdas" }
@@ -97,11 +108,13 @@ Resources:
       MemorySize: 128
       Environment:
         Variables:
-          BUILDKITE_AGENT_TOKEN: !Ref BuildkiteAgentToken
-          BUILDKITE_QUEUE:       !Ref BuildkiteQueue
-          ASG_NAME:              !Ref AgentAutoScaleGroup
-          LAMBDA_TIMEOUT:        1m
-          LAMBDA_INTERVAL:       20s
+          BUILDKITE_AGENT_TOKEN:    !Ref BuildkiteAgentToken
+          BUILDKITE_QUEUE:          !Ref BuildkiteQueue
+          ASG_NAME:                 !Ref AgentAutoScaleGroup
+          SCALE_IN_COOLDOWN_PERIOD: !Ref ScaleInCooldownPeriod
+          SCALE_IN_ADJUSTMENT:      !Ref ScaleInAdjustment
+          LAMBDA_TIMEOUT:           1m
+          LAMBDA_INTERVAL:          20s
 
   AutoscalingLambdaScheduledRule:
     Type: "AWS::Events::Rule"


### PR DESCRIPTION
This reimplements ASG scale-in cooldown inside the lambda. It takes two parameters which correspond to the existing ASG parameters in the elastic CI stack.

1. `SCALE_IN_COOLDOWN_PERIOD` is the cooldown time between scale in events. This defaults to the existing 5 minutes.

2. `SCALE_IN_ADJUSTMENT` is the maximum adjustment during scale-in events. Unlike the ASG we may scale in less if we calculate that the desired is closer than the adjustment. This defaults to the existing -1.

This cheats a bit by storing `lastScaleInTime` in a global variable. This means we'll forget about our cooldown during a cold start. This should happen fairly infrequently and just make us a bit aggressive about scaling it; it shouldn't affect correctness.