### PR TITLE
Add DISABLE_SCALE_IN param to opt-out of scale in

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -118,6 +118,11 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				params.PublishCloudWatchMetrics = true
 			}
 
+			if m := os.Getenv(`DISABLE_SCALE_IN`); m == `true` || m == `1` {
+				log.Printf("Disabling scale-in")
+				params.ScaleInParams.Disable = true
+			}
+
 			scaler, err := scaler.NewScaler(client, params)
 			if err != nil {
 				log.Fatal(err)

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -9,6 +9,7 @@ import (
 )
 
 type ScaleInParams struct {
+	Disable         bool
 	CooldownPeriod  time.Duration
 	Adjustment      int64
 	LastScaleInTime *time.Time
@@ -117,6 +118,11 @@ func (s *Scaler) Run() error {
 
 		log.Printf("↳ Set desired to %d (took %v)", desired, time.Now().Sub(t))
 	} else if current.DesiredCount > desired {
+		if s.scaleInParams.Disable {
+			log.Printf("Skipping scale IN, disabled")
+			return nil
+		}
+
 		cooldownRemaining := s.scaleInParams.CooldownPeriod - time.Since(*s.scaleInParams.LastScaleInTime)
 
 		if cooldownRemaining > 0 {


### PR DESCRIPTION
This allows opting out of scale-in for cases where the agent's new disconnect when idle feature is used. 