### PR TITLE
Replace adjustments with min/max for scale in and out

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,8 +20,11 @@ func main() {
 		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
 		buildkiteAgentToken = flag.String("agent-token", "", "A buildkite agent registration token")
 
-		// scale in params
-		scaleInAdjustment = flag.Int64("scale-in-adjustment", -1, "Maximum adjustment to the desired capacity on scale in")
+		// scale in/out params
+		scaleInMinAdjustment  = flag.Int64("scale-in-min", 0, "A lower bound for negative desired count changes")
+		scaleInMaxAdjustment  = flag.Int64("scale-in-max", 0, "An upper bound for negative desired count changes")
+		scaleOutMinAdjustment = flag.Int64("scale-out-min", 0, "A lower bound for positive desired count changes")
+		scaleOutMaxAdjustment = flag.Int64("scale-out-max", 0, "An upper bound for positive desired count changes")
 
 		// general params
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
@@ -37,10 +40,12 @@ func main() {
 		PublishCloudWatchMetrics: *cwMetrics,
 		DryRun:                   *dryRun,
 		ScaleInParams: scaler.ScaleInParams{
-			// We run in one-shot so cooldown isn't implemented
-			CooldownPeriod:  time.Duration(0),
-			Adjustment:      *scaleInAdjustment,
-			LastScaleInTime: &time.Time{},
+			MinAdjustment: *scaleInMinAdjustment,
+			MaxAdjustment: *scaleInMaxAdjustment,
+		},
+		ScaleOutParams: scaler.ScaleOutParams{
+			MinAdjustment: *scaleOutMinAdjustment,
+			MaxAdjustment: *scaleOutMaxAdjustment,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Currently we have scale-in-adjustment and cooldown, but when I went to extend this to a scale-out adjustment I realized that there are two distinct use cases, a minimum bound and a maximum bound for each scaling direction.

For scale-in, you might want to slow down scale-in, for which you'd set a `scale-in-max` of say `-2`, which would ensure that the scale-in didn't move by more than `-2`. Alternately, you might (for some reason) want to scale in always by the maximum, so you could set a `scale-in-min` of `-100`. This one is pretty tenuous, but I implemented it to match it's more useful `scale-out-max`.

For scale-out, you might want to have faster scale-out, so you set a `scale-out-min` of 20, which means that you always scale by at least 20 instances. If you set `scale-out-min`, you can control the speed at which scale out runs. 

I also implemented a `disable` switch for scale-out and a cooldown timer if you are so inclined.

@etaoins I'd love your feedback on `scale-in-adjustment` vs `scale-in-min` and `scale-in-max`. Min/max with negative numbers is super confusing but I couldn't figure out how to handle the scale out and keep them consistent 🤔