### PR TITLE
Add a configurable scale factor to scale in/out

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"strconv"
 	"time"
@@ -16,11 +17,11 @@ import (
 	"github.com/buildkite/buildkite-agent-scaler/version"
 )
 
-var invokeCount = 0
-
-// lastScaleDownTime stores the last time we scaled down the ASG
-// On a cold start this will be reset to Jan 1st, 1970
-var lastScaleInTime time.Time
+// Stores the last time we scaled in/out in global lambda state
+// On a cold start this will be reset to a zero value
+var (
+	lastScaleIn, lastScaleOut time.Time
+)
 
 func main() {
 	if os.Getenv(`DEBUG`) != "" {
@@ -29,8 +30,6 @@ func main() {
 			log.Fatal(err)
 		}
 	} else {
-		invokeCount = invokeCount + 1
-		log.Printf("Invocation count %d", invokeCount)
 		lambda.Start(Handler)
 	}
 }
@@ -38,45 +37,57 @@ func main() {
 func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	log.Printf("buildkite-agent-scaler version %s", version.VersionString())
 
-	var timeout <-chan time.Time = make(chan time.Time)
-	var interval time.Duration = 10 * time.Second
-	var scaleInCooldownPeriod time.Duration = 5 * time.Minute
-	var scaleInAdjustment int64 = -1
+	var (
+		timeout  <-chan time.Time = make(chan time.Time)
+		interval time.Duration    = 10 * time.Second
 
-	if intervalStr := os.Getenv(`LAMBDA_INTERVAL`); intervalStr != "" {
-		var err error
-		interval, err = time.ParseDuration(intervalStr)
-		if err != nil {
+		scaleInCooldownPeriod time.Duration
+		scaleInFactor         float64
+
+		scaleOutCooldownPeriod time.Duration
+		scaleOutFactor         float64
+
+		err error
+	)
+
+	if v := os.Getenv(`LAMBDA_INTERVAL`); v != "" {
+		if interval, err = time.ParseDuration(v); err != nil {
 			return "", err
 		}
 	}
 
-	if timeoutStr := os.Getenv(`LAMBDA_TIMEOUT`); timeoutStr != "" {
-		timeoutDuration, err := time.ParseDuration(timeoutStr)
-		if err != nil {
+	if v := os.Getenv(`LAMBDA_INTERVAL`); v != "" {
+		if timeoutDuration, err := time.ParseDuration(v); err != nil {
 			return "", err
-		}
-		timeout = time.After(timeoutDuration)
-	}
-
-	if scaleInCooldownPeriodStr := os.Getenv(`SCALE_IN_COOLDOWN_PERIOD`); scaleInCooldownPeriodStr != "" {
-		var err error
-		scaleInCooldownPeriod, err = time.ParseDuration(scaleInCooldownPeriodStr)
-		if err != nil {
-			return "", err
+		} else {
+			timeout = time.After(timeoutDuration)
 		}
 	}
 
-	if scaleInAdjustmentStr := os.Getenv(`SCALE_IN_ADJUSTMENT`); scaleInAdjustmentStr != "" {
-		var err error
-		scaleInAdjustment, err = strconv.ParseInt(scaleInAdjustmentStr, 10, 64)
-		if err != nil {
+	if v := os.Getenv(`SCALE_IN_COOLDOWN_PERIOD`); v != "" {
+		if scaleInCooldownPeriod, err = time.ParseDuration(v); err != nil {
 			return "", err
 		}
+	}
 
-		if scaleInAdjustment >= 0 {
-			panic(fmt.Sprintf("Scale in adjustment (%d) must be negative", scaleInAdjustment))
+	if v := os.Getenv(`SCALE_IN_FACTOR`); v != "" {
+		if scaleInFactor, err = strconv.ParseFloat(v, 64); err != nil {
+			return "", err
 		}
+		scaleInFactor = math.Abs(scaleInFactor)
+	}
+
+	if v := os.Getenv(`SCALE_OUT_COOLDOWN_PERIOD`); v != "" {
+		if scaleOutCooldownPeriod, err = time.ParseDuration(v); err != nil {
+			return "", err
+		}
+	}
+
+	if v := os.Getenv(`SCALE_OUT_FACTOR`); v != "" {
+		if scaleOutFactor, err = strconv.ParseFloat(v, 64); err != nil {
+			return "", err
+		}
+		scaleOutFactor = math.Abs(scaleOutFactor)
 	}
 
 	var mustGetEnv = func(env string) string {
@@ -124,10 +135,15 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				BuildkiteQueue:       mustGetEnv(`BUILDKITE_QUEUE`),
 				AutoScalingGroupName: mustGetEnv(`ASG_NAME`),
 				AgentsPerInstance:    mustGetEnvInt(`AGENTS_PER_INSTANCE`),
-				ScaleInParams: scaler.ScaleInParams{
-					CooldownPeriod:  scaleInCooldownPeriod,
-					Adjustment:      scaleInAdjustment,
-					LastScaleInTime: &lastScaleInTime,
+				ScaleInParams: scaler.ScaleParams{
+					CooldownPeriod: scaleInCooldownPeriod,
+					Factor:         scaleInFactor,
+					LastEvent:      lastScaleIn,
+				},
+				ScaleOutParams: scaler.ScaleParams{
+					CooldownPeriod: scaleOutCooldownPeriod,
+					Factor:         scaleOutFactor,
+					LastEvent:      lastScaleOut,
 				},
 			}
 
@@ -137,8 +153,13 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			}
 
 			if m := os.Getenv(`DISABLE_SCALE_IN`); m == `true` || m == `1` {
-				log.Printf("Disabling scale-in")
+				log.Printf("Disabling scale-in 🙅🏼‍")
 				params.ScaleInParams.Disable = true
+			}
+
+			if m := os.Getenv(`DISABLE_SCALE_OUT`); m == `true` || m == `1` {
+				log.Printf("Disabling scale-out 🙅🏼‍♂️")
+				params.ScaleOutParams.Disable = true
 			}
 
 			scaler, err := scaler.NewScaler(client, params)
@@ -156,6 +177,9 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				log.Printf("Increasing poll interval to %v based on rate limit",
 					interval)
 			}
+			// Persist the times back into the global state
+			lastScaleIn = scaler.LastScaleIn()
+			lastScaleOut = scaler.LastScaleOut()
 
 			log.Printf("Waiting for %v", interval)
 			time.Sleep(interval)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"log"
-	"time"
 
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 	"github.com/buildkite/buildkite-agent-scaler/scaler"
@@ -21,8 +20,9 @@ func main() {
 		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
 		buildkiteAgentToken = flag.String("agent-token", "", "A buildkite agent registration token")
 
-		// scale in params
-		scaleInAdjustment = flag.Int64("scale-in-adjustment", -1, "Maximum adjustment to the desired capacity on scale in")
+		// scale in/out params
+		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
+		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
 		// general params
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
@@ -45,12 +45,8 @@ func main() {
 		AgentsPerInstance:        *agentsPerInstance,
 		PublishCloudWatchMetrics: *cwMetrics,
 		DryRun:                   *dryRun,
-		ScaleInParams: scaler.ScaleInParams{
-			// We run in one-shot so cooldown isn't implemented
-			CooldownPeriod:  time.Duration(0),
-			Adjustment:      *scaleInAdjustment,
-			LastScaleInTime: &time.Time{},
-		},
+		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
+		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This adds a scale-in and scale-out factor that can be used to speed up or slow down scale outs and ins. 

For instance, setting `SCALE_IN_FACTOR=0.5` will reduce the change applied in each scale in by 50%.  Setting `SCALE_OUT_FACTOR=2.0` will increase each scale out change by 200%.

This is a simpler take on #12.