### PR TITLE
Respect poll duration header from agent api

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -128,8 +128,15 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				log.Fatal(err)
 			}
 
-			if err := scaler.Run(); err != nil {
+			minPollDuration, err := scaler.Run()
+			if err != nil {
 				log.Printf("Scaling error: %v", err)
+			}
+
+			if interval < minPollDuration {
+				interval = minPollDuration
+				log.Printf("Increasing poll interval to %v based on rate limit",
+					interval)
 			}
 
 			log.Printf("Waiting for %v", interval)


### PR DESCRIPTION
The Buildkite Agent Metrics API returns a header` Buildkite-Agent-Metrics-Poll-Duration` that indicates the minimum poll duration. This is generally 10s, but under periods of heavy load it can scale up.

This limit is enforced in the cli tool and also in the lambda via global state.