### PR TITLE
Support reading Agent Token from SSM Parameter Store

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 		asgName           = flag.String("asg-name", "", "The name of the autoscaling group")
 		agentsPerInstance = flag.Int("agents-per-instance", 1, "The number of agents per instance")
 		cwMetrics         = flag.Bool("cloudwatch-metrics", false, "Whether to publish cloudwatch metrics")
+		ssmTokenKey       = flag.String("agent-token-ssm-key", "", "The AWS SSM Parameter Store key for the agent token")
 
 		// buildkite params
 		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
@@ -27,6 +28,14 @@ func main() {
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
 	)
 	flag.Parse()
+
+	if *ssmTokenKey != "" {
+		token, err := scaler.RetrieveFromParameterStore(*ssmTokenKey)
+		if err != nil {
+			log.Fatal(err)
+		}
+		buildkiteAgentToken = &token
+	}
 
 	client := buildkite.NewClient(*buildkiteAgentToken)
 

--- a/scaler/ssm.go
+++ b/scaler/ssm.go
@@ -1,0 +1,20 @@
+package scaler
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+)
+
+func RetrieveFromParameterStore(key string) (string, error) {
+	ssmClient := ssm.New(session.New())
+	output, err := ssmClient.GetParameter(&ssm.GetParameterInput{
+		Name:           &key,
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return *output.Parameter.Value, nil
+}


### PR DESCRIPTION
This allows for the Agent Token to be read from SSM Parameter Store, which means it doesn't need to be passed in plain text via the lambda env.

The ParameterStore key can be set via `BUILDKITE_AGENT_TOKEN_SSM_KEY`.