### PR TITLE
Add scaling to include waiting jobs

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -37,6 +37,7 @@ type AgentMetrics struct {
 	ScheduledJobs int64
 	RunningJobs   int64
 	PollDuration  time.Duration
+	WaitingJobs   int64
 }
 
 func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
@@ -50,6 +51,7 @@ func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
 			Queues map[string]struct {
 				Scheduled int64 `json:"scheduled"`
 				Running   int64 `json:"running"`
+				Waiting   int64 `json:"waiting"`
 			} `json:"queues"`
 		} `json:"jobs"`
 	}
@@ -70,10 +72,11 @@ func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
 	if queue, exists := resp.Jobs.Queues[queue]; exists {
 		metrics.ScheduledJobs = queue.Scheduled
 		metrics.RunningJobs = queue.Running
+		metrics.WaitingJobs = queue.Waiting
 	}
 
-	log.Printf("↳ Got scheduled=%d, running=%d (took %v)",
-		metrics.ScheduledJobs, metrics.RunningJobs, queryDuration)
+	log.Printf("↳ Got scheduled=%d, running=%d, waiting=%d (took %v)",
+		metrics.ScheduledJobs, metrics.RunningJobs, metrics.WaitingJobs, queryDuration)
 	return metrics, nil
 }
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -47,8 +47,8 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		scaleOutCooldownPeriod time.Duration
 		scaleOutFactor         float64
 
-		ignoreWaiting bool
-		err           error
+		includeWaiting bool
+		err            error
 	)
 
 	if v := os.Getenv(`LAMBDA_INTERVAL`); v != "" {
@@ -91,9 +91,9 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		scaleOutFactor = math.Abs(scaleOutFactor)
 	}
 
-	if v := os.Getenv(`IGNORE_WAITING`); v != "" {
+	if v := os.Getenv(`INCLUDE_WAITING`); v != "" {
 		if v == "true" || v == "1" {
-			ignoreWaiting = true
+			includeWaiting = true
 		}
 	}
 
@@ -142,7 +142,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				BuildkiteQueue:       mustGetEnv(`BUILDKITE_QUEUE`),
 				AutoScalingGroupName: mustGetEnv(`ASG_NAME`),
 				AgentsPerInstance:    mustGetEnvInt(`AGENTS_PER_INSTANCE`),
-				IgnoreWaiting:        ignoreWaiting,
+				IncludeWaiting:       includeWaiting,
 				ScaleInParams: scaler.ScaleParams{
 					CooldownPeriod: scaleInCooldownPeriod,
 					Factor:         scaleInFactor,

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -47,7 +47,8 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		scaleOutCooldownPeriod time.Duration
 		scaleOutFactor         float64
 
-		err error
+		ignoreWaiting bool
+		err           error
 	)
 
 	if v := os.Getenv(`LAMBDA_INTERVAL`); v != "" {
@@ -89,6 +90,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			return "", err
 		}
 		scaleOutFactor = math.Abs(scaleOutFactor)
+	}
+
+	if v := os.Getenv(`IGNORE_WAITING`); v != "" {
+		if v == "true" || v == "1" {
+			ignoreWaiting = true
+		}
 	}
 
 	var mustGetEnv = func(env string) string {
@@ -136,6 +143,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				BuildkiteQueue:       mustGetEnv(`BUILDKITE_QUEUE`),
 				AutoScalingGroupName: mustGetEnv(`ASG_NAME`),
 				AgentsPerInstance:    mustGetEnvInt(`AGENTS_PER_INSTANCE`),
+				IgnoreWaiting:        ignoreWaiting,
 				ScaleInParams: scaler.ScaleParams{
 					CooldownPeriod: scaleInCooldownPeriod,
 					Factor:         scaleInFactor,

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -82,7 +82,6 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		if scaleOutCooldownPeriod, err = time.ParseDuration(v); err != nil {
 			return "", err
 		}
-		scaleOutFactor = math.Abs(scaleOutFactor)
 	}
 
 	if v := os.Getenv(`SCALE_OUT_FACTOR`); v != "" {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -81,6 +81,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		if scaleOutCooldownPeriod, err = time.ParseDuration(v); err != nil {
 			return "", err
 		}
+		scaleOutFactor = math.Abs(scaleOutFactor)
 	}
 
 	if v := os.Getenv(`SCALE_OUT_FACTOR`); v != "" {
@@ -177,6 +178,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				log.Printf("Increasing poll interval to %v based on rate limit",
 					interval)
 			}
+
 			// Persist the times back into the global state
 			lastScaleIn = scaler.LastScaleIn()
 			lastScaleOut = scaler.LastScaleOut()

--- a/main.go
+++ b/main.go
@@ -17,9 +17,9 @@ func main() {
 		ssmTokenKey       = flag.String("agent-token-ssm-key", "", "The AWS SSM Parameter Store key for the agent token")
 
 		// buildkite params
-		buildkiteQueue         = flag.String("queue", "default", "The queue to watch in the metrics")
-		buildkiteAgentToken    = flag.String("agent-token", "", "A buildkite agent registration token")
-		buildkiteIgnoreWaiting = flag.Bool("ignore-waiting", false, "Whether to ignore jobs behind a wait step for scaling")
+		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
+		buildkiteAgentToken = flag.String("agent-token", "", "A buildkite agent registration token")
+		includeWaiting      = flag.Bool("include-waiting", false, "Whether to include jobs behind a wait step for scaling")
 
 		// scale in/out params
 		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
@@ -46,7 +46,7 @@ func main() {
 		AgentsPerInstance:        *agentsPerInstance,
 		PublishCloudWatchMetrics: *cwMetrics,
 		DryRun:                   *dryRun,
-		IgnoreWaiting:            *buildkiteIgnoreWaiting,
+		IncludeWaiting:           *includeWaiting,
 		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
 		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
 	})

--- a/main.go
+++ b/main.go
@@ -17,8 +17,9 @@ func main() {
 		ssmTokenKey       = flag.String("agent-token-ssm-key", "", "The AWS SSM Parameter Store key for the agent token")
 
 		// buildkite params
-		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
-		buildkiteAgentToken = flag.String("agent-token", "", "A buildkite agent registration token")
+		buildkiteQueue         = flag.String("queue", "default", "The queue to watch in the metrics")
+		buildkiteAgentToken    = flag.String("agent-token", "", "A buildkite agent registration token")
+		buildkiteIgnoreWaiting = flag.Bool("ignore-waiting", false, "Whether to ignore jobs behind a wait step for scaling")
 
 		// scale in/out params
 		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
@@ -45,6 +46,7 @@ func main() {
 		AgentsPerInstance:        *agentsPerInstance,
 		PublishCloudWatchMetrics: *cwMetrics,
 		DryRun:                   *dryRun,
+		IgnoreWaiting:            *buildkiteIgnoreWaiting,
 		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
 		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
 	})

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -93,12 +93,16 @@ func (s *Scaler) Run() (time.Duration, error) {
 		}
 	}
 
-	count := metrics.ScheduledJobs + metrics.RunningJobs
+	count := metrics.ScheduledJobs
 
-	if s.includeWaiting {
+	// If waiting jobs are greater than running jobs then optionally
+	// use waiting jobs for scaling so that we have instances booted
+	// by the time we get to them. This is a gamble, as if the instances
+	// scale down before the jobs get scheduled, it's a huge waste.
+	if s.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
 		count += metrics.WaitingJobs
 	} else {
-		log.Printf("💸 Ignoring %d waiting jobs", metrics.WaitingJobs)
+		count += metrics.RunningJobs
 	}
 
 	var desired int64

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -23,7 +23,7 @@ type Params struct {
 	UserAgent                string
 	PublishCloudWatchMetrics bool
 	DryRun                   bool
-	IgnoreWaiting            bool
+	IncludeWaiting           bool
 	ScaleInParams            ScaleParams
 	ScaleOutParams           ScaleParams
 }
@@ -39,7 +39,7 @@ type Scaler struct {
 	metrics interface {
 		Publish(orgSlug, queue string, metrics map[string]int64) error
 	}
-	ignoreWaiting     bool
+	includeWaiting    bool
 	agentsPerInstance int
 	scaleInParams     ScaleParams
 	scaleOutParams    ScaleParams
@@ -51,7 +51,7 @@ func NewScaler(client *buildkite.Client, params Params) (*Scaler, error) {
 			client: client,
 			queue:  params.BuildkiteQueue,
 		},
-		ignoreWaiting:     params.IgnoreWaiting,
+		includeWaiting:    params.IncludeWaiting,
 		agentsPerInstance: params.AgentsPerInstance,
 		scaleInParams:     params.ScaleInParams,
 		scaleOutParams:    params.ScaleOutParams,
@@ -95,7 +95,7 @@ func (s *Scaler) Run() (time.Duration, error) {
 
 	count := metrics.ScheduledJobs + metrics.RunningJobs
 
-	if !s.ignoreWaiting {
+	if s.includeWaiting {
 		count += metrics.WaitingJobs
 	} else {
 		log.Printf("💸 Ignoring %d waiting jobs", metrics.WaitingJobs)

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -31,13 +31,13 @@ func TestScalingOutWithoutError(t *testing.T) {
 			metrics: buildkite.AgentMetrics{
 				ScheduledJobs: 8,
 				RunningJobs:   2,
-				WaitingJobs:   2,
+				WaitingJobs:   20,
 			},
 			params: Params{
 				AgentsPerInstance: 1,
-				IncludeWaiting:     true,
+				IncludeWaiting:    true,
 			},
-			expectedDesiredCapacity: 12,
+			expectedDesiredCapacity: 28,
 		},
 		// Scale-out with multiple agents per instance
 		{
@@ -185,7 +185,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 				bk:                &buildkiteTestDriver{metrics: tc.metrics},
 				agentsPerInstance: tc.params.AgentsPerInstance,
 				scaleOutParams:    tc.params.ScaleOutParams,
-				includeWaiting:     tc.params.IncludeWaiting,
+				includeWaiting:    tc.params.IncludeWaiting,
 			}
 
 			if _, err := s.Run(); err != nil {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -14,11 +14,25 @@ func TestScalingOutWithoutError(t *testing.T) {
 		currentDesiredCapacity  int64
 		expectedDesiredCapacity int64
 	}{
-		// Basic scale out
+		// Basic scale out without waiting jobs
 		{
 			metrics: buildkite.AgentMetrics{
 				ScheduledJobs: 10,
 				RunningJobs:   2,
+				WaitingJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				IgnoreWaiting:     true,
+			},
+			expectedDesiredCapacity: 12,
+		},
+		// Basic scale out with waiting jobs
+		{
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 8,
+				RunningJobs:   2,
+				WaitingJobs:   2,
 			},
 			params: Params{
 				AgentsPerInstance: 1,
@@ -171,6 +185,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 				bk:                &buildkiteTestDriver{metrics: tc.metrics},
 				agentsPerInstance: tc.params.AgentsPerInstance,
 				scaleOutParams:    tc.params.ScaleOutParams,
+				ignoreWaiting:     tc.params.IgnoreWaiting,
 			}
 
 			if _, err := s.Run(); err != nil {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -23,7 +23,6 @@ func TestScalingOutWithoutError(t *testing.T) {
 			},
 			params: Params{
 				AgentsPerInstance: 1,
-				IgnoreWaiting:     true,
 			},
 			expectedDesiredCapacity: 12,
 		},
@@ -36,6 +35,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 			},
 			params: Params{
 				AgentsPerInstance: 1,
+				IncludeWaiting:     true,
 			},
 			expectedDesiredCapacity: 12,
 		},
@@ -185,7 +185,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 				bk:                &buildkiteTestDriver{metrics: tc.metrics},
 				agentsPerInstance: tc.params.AgentsPerInstance,
 				scaleOutParams:    tc.params.ScaleOutParams,
-				ignoreWaiting:     tc.params.IgnoreWaiting,
+				includeWaiting:     tc.params.IncludeWaiting,
 			}
 
 			if _, err := s.Run(); err != nil {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -8,106 +8,169 @@ import (
 )
 
 func TestScalingOutWithoutError(t *testing.T) {
-	metrics := buildkite.AgentMetrics{
-		ScheduledJobs: 10,
-		RunningJobs:   2,
-	}
-
 	for _, tc := range []struct {
-		agentsPerInstance       int
+		params                  Params
+		metrics                 buildkite.AgentMetrics
 		currentDesiredCapacity  int64
-		params                  ScaleParams
 		expectedDesiredCapacity int64
 	}{
 		// Basic scale out
 		{
-			agentsPerInstance:       1,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+			},
 			expectedDesiredCapacity: 12,
 		},
 		// Scale-out with multiple agents per instance
 		{
-			agentsPerInstance:       4,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 4,
+			},
 			expectedDesiredCapacity: 3,
 		},
 		{
-			agentsPerInstance:       2,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 2,
+			},
 			expectedDesiredCapacity: 6,
 		},
 		// Scale-out with multiple agents per instance
 		// where it doesn't divide evenly
 		{
-			agentsPerInstance:       5,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 5,
+			},
 			expectedDesiredCapacity: 3,
 		},
 		{
-			agentsPerInstance:       20,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 20,
+			},
 			expectedDesiredCapacity: 1,
 		},
 		// Scale-out with a factor of 50%
 		{
-			agentsPerInstance: 1,
-			params: ScaleParams{
-				Factor: 0.5,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					Factor: 0.5,
+				},
 			},
 			expectedDesiredCapacity: 6,
 		},
 		// Scale-out with a factor of 10%
 		{
-			agentsPerInstance: 1,
-			params: ScaleParams{
-				Factor: 0.10,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
 			},
-			currentDesiredCapacity: 11,
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					Factor: 0.10,
+				},
+			},
+			currentDesiredCapacity:  11,
 			expectedDesiredCapacity: 12,
 		},
 		// Cool-down period is enforced
 		{
-			agentsPerInstance: 1,
-			params: ScaleParams{
-				LastEvent:   time.Now(),
-				CooldownPeriod: 5 * time.Minute,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					LastEvent:      time.Now(),
+					CooldownPeriod: 5 * time.Minute,
+				},
 			},
 			currentDesiredCapacity:  4,
 			expectedDesiredCapacity: 4,
 		},
 		// Cool-down period is passed
 		{
-			agentsPerInstance: 1,
-			params: ScaleParams{
-				LastEvent:   time.Now().Add(-10 * time.Minute),
-				CooldownPeriod: 5 * time.Minute,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					LastEvent:      time.Now().Add(-10 * time.Minute),
+					CooldownPeriod: 5 * time.Minute,
+				},
 			},
 			currentDesiredCapacity:  4,
 			expectedDesiredCapacity: 12,
 		},
 		// Cool-down period is passed, factor is applied
 		{
-			agentsPerInstance: 1,
-			params: ScaleParams{
-				Factor:  2.0,
-				LastEvent:   time.Now().Add(-10 * time.Minute),
-				CooldownPeriod: 5 * time.Minute,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					Factor:         2.0,
+					LastEvent:      time.Now().Add(-10 * time.Minute),
+					CooldownPeriod: 5 * time.Minute,
+				},
 			},
 			currentDesiredCapacity:  4,
 			expectedDesiredCapacity: 20,
 		},
 		// Scale out disabled
 		{
-			agentsPerInstance: 1,
-			params: ScaleParams{
-				Disable: true,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					Disable: true,
+				},
 			},
 			currentDesiredCapacity:  1,
 			expectedDesiredCapacity: 1,
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			asg := &asgTestDriver{desiredCapacity: tc.currentDesiredCapacity}
+			asg := &asgTestDriver{
+				desiredCapacity: tc.currentDesiredCapacity,
+			}
 			s := Scaler{
 				autoscaling:       asg,
-				bk:                &buildkiteTestDriver{metrics: metrics},
-				agentsPerInstance: tc.agentsPerInstance,
-				scaleOutParams:    tc.params,
+				bk:                &buildkiteTestDriver{metrics: tc.metrics},
+				agentsPerInstance: tc.params.AgentsPerInstance,
+				scaleOutParams:    tc.params.ScaleOutParams,
 			}
 
 			if _, err := s.Run(); err != nil {
@@ -125,51 +188,67 @@ func TestScalingOutWithoutError(t *testing.T) {
 
 func TestScalingInWithoutError(t *testing.T) {
 	testCases := []struct {
+		params                  Params
+		metrics                 buildkite.AgentMetrics
 		currentDesiredCapacity  int64
-		scheduledJobs           int64
-		params                  ScaleParams
 		expectedDesiredCapacity int64
 	}{
 		// We're inside cooldown
 		{
-			currentDesiredCapacity: 10,
-			params: ScaleParams{
-				CooldownPeriod: 5 * time.Minute,
-				LastEvent:    time.Now(),
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleInParams: ScaleParams{
+					CooldownPeriod: 5 * time.Minute,
+					LastEvent:      time.Now(),
+				},
 			},
+			currentDesiredCapacity:  10,
 			expectedDesiredCapacity: 10,
 		},
 		// We're out of cooldown, apply factor
 		{
-			currentDesiredCapacity: 10,
-			params: ScaleParams{
-				CooldownPeriod: 5 * time.Minute,
-				LastEvent:    time.Now().Add(-10 * time.Minute),
-				Factor:  0.10,
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleInParams: ScaleParams{
+					CooldownPeriod: 5 * time.Minute,
+					LastEvent:      time.Now().Add(-10 * time.Minute),
+					Factor:         0.10,
+				},
 			},
+			currentDesiredCapacity:  10,
 			expectedDesiredCapacity: 9,
 		},
 		// With 500% factor, we scale all the way down despite scheduled jobs
 		{
-			currentDesiredCapacity: 20,
-			scheduledJobs:          10,
-			params: ScaleParams{
-				Factor: 5.0,
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
 			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleInParams: ScaleParams{
+					Factor: 5.0,
+				},
+			},
+			currentDesiredCapacity:  20,
 			expectedDesiredCapacity: 0,
 		},
 		// Make sure we round down so we eventually reach zero
 		{
-			currentDesiredCapacity: 1,
-			params: ScaleParams{
-				Factor: 0.10,
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleInParams: ScaleParams{
+					Factor: 0.10,
+				},
 			},
+			currentDesiredCapacity:  1,
 			expectedDesiredCapacity: 0,
 		},
 		// Scale in disabled
 		{
-			params: ScaleParams{
-				Disable: true,
+			params: Params{
+				ScaleInParams: ScaleParams{
+					Disable: true,
+				},
 			},
 			currentDesiredCapacity:  1,
 			expectedDesiredCapacity: 1,
@@ -178,14 +257,14 @@ func TestScalingInWithoutError(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			asg := &asgTestDriver{desiredCapacity: tc.currentDesiredCapacity}
+			asg := &asgTestDriver{
+				desiredCapacity: tc.currentDesiredCapacity,
+			}
 			s := Scaler{
-				autoscaling: asg,
-				bk: &buildkiteTestDriver{metrics: buildkite.AgentMetrics{
-					ScheduledJobs: tc.scheduledJobs,
-				}},
-				agentsPerInstance: 1,
-				scaleInParams:     tc.params,
+				autoscaling:       asg,
+				bk:                &buildkiteTestDriver{metrics: tc.metrics},
+				agentsPerInstance: tc.params.AgentsPerInstance,
+				scaleInParams:     tc.params.ScaleInParams,
 			}
 
 			if _, err := s.Run(); err != nil {


### PR DESCRIPTION
The agent metrics api now includes a metric for `WaitingJobCount` which tracks jobs that are behind a wait step. This allows for pre-emptive scaling so that instances are ready by the time that jobs are scheduled. 

By default `waiting` jobs aren't included, but they can be enabled with `INCLUDE_WAITING=1` in the lambda env. 