### PR TITLE
Correct required environment variables in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ It's entrypoint is `handler`, it requires a `go1.x` environment and requires the
 - `BUILDKITE_QUEUE`
 - `AGENTS_PER_INSTANCE`
 - `ASG_NAME`
-- `MIN_SIZE`
-- `MAX_SIZE`
 
 ```bash
 aws lambda create-function \


### PR DESCRIPTION
The MIN_SIZE and MAX_SIZE variables are not used by the lambda. These
parameters are queried from the Autoscaling Group rather than the
environment.