### PR TITLE
Handle HTTP errors from metrics API

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -102,6 +102,9 @@ func (c *Client) queryMetrics(into interface{}) (pollDuration time.Duration, err
 		return time.Duration(0), err
 	}
 	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return time.Duration(0), fmt.Errorf("%s %s: %s", method, endpoint, res.Status)
+	}
 
 	// Check if we get a poll duration header from server
 	if pollSeconds := res.Header.Get(PollDurationHeader); pollSeconds != "" {

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -100,6 +100,7 @@ func (c *Client) queryMetrics(into interface{}) (pollDuration time.Duration, err
 	if err != nil {
 		return time.Duration(0), err
 	}
+	defer res.Body.Close()
 
 	// Check if we get a poll duration header from server
 	if pollSeconds := res.Header.Get(PollDurationHeader); pollSeconds != "" {
@@ -111,6 +112,5 @@ func (c *Client) queryMetrics(into interface{}) (pollDuration time.Duration, err
 		}
 	}
 
-	defer res.Body.Close()
 	return pollDuration, json.NewDecoder(res.Body).Decode(into)
 }

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -86,9 +86,10 @@ func (c *Client) queryMetrics(into interface{}) (pollDuration time.Duration, err
 		return time.Duration(0), err
 	}
 
+	method := http.MethodGet
 	endpoint.Path += "/metrics"
 
-	req, err := http.NewRequest("GET", endpoint.String(), nil)
+	req, err := http.NewRequest(method, endpoint.String(), nil)
 	if err != nil {
 		return time.Duration(0), err
 	}

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -1,0 +1,40 @@
+package buildkite
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHappy(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"organization": {"slug": "llamacorp"}}`)
+	}))
+	c := NewClient("testtoken")
+	c.Endpoint = s.URL
+	m, err := c.GetAgentMetrics("default")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		return
+	}
+	if want, got := "llamacorp", m.OrgSlug; want != got {
+		t.Errorf("OrgSlug: wanted %s, got %s", want, got)
+	}
+}
+
+func TestUnauthorizedResponse(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		io.WriteString(w, `{"message": "Eeep! You forgot to pass an agent registration token"}`)
+	}))
+	c := NewClient("testtoken")
+	c.Endpoint = s.URL
+	_, err := c.GetAgentMetrics("default")
+	if err != nil {
+		t.Log("(expected error)", err)
+	} else {
+		t.Error("expected error representing non-200 HTTP status")
+	}
+}


### PR DESCRIPTION
`buildkite.Client.GetAgentMetrics()` was not handling HTTP errors, and instead returning an empty `AgentMetrics` struct.

This manifested as an apparent zero-value for all metrics, and an empty `org` field in the log output:

```
2019/11/21 19:38:23 Publishing metric WaitingJobsCount=0 [org=,queue=default]
```

Go's HTTP client says:

> A non-2xx status code doesn't cause an error. 
-- https://golang.org/pkg/net/http/#Client.Do

This PR adds status-checking code, and tests for the happy and sad cases.