### PR TITLE
README: read token from AWS Parameter Store / Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ An AWS Lambda bundle is created and published as part of the build process. The 
 
 It's entrypoint is `handler`, it requires a `go1.x` environment and requires the following env vars:
 
-- `BUILDKITE_AGENT_TOKEN`
+- `BUILDKITE_AGENT_TOKEN` or `BUILDKITE_AGENT_TOKEN_SSM_KEY`
 - `BUILDKITE_QUEUE`
 - `AGENTS_PER_INSTANCE`
 - `ASG_NAME`
+
+If `BUILDKITE_AGENT_TOKEN_SSM_KEY` is set, the token will be read from [AWS Systems Manager Parameter Store GetParameter](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html) which [can also read from AWS Secrets Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/integration-ps-secretsmanager.html).
 
 ```bash
 aws lambda create-function \


### PR DESCRIPTION
Document the fact that the agent registration token can be read from AWS Parameter Store or Secrets Manager at runtime, rather than being passed directly in the environment.