### PR TITLE
run deploy steps on the new "deploy"  queue

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -5,7 +5,7 @@ steps:
     command: ".buildkite/steps/release-version.sh"
     branches: master
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
     concurrency: 1
     concurrency_group: 'release'
 
@@ -14,6 +14,13 @@ steps:
     command: ".buildkite/steps/github-release.sh"
     branches: master
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
     concurrency: 1
     concurrency_group: 'release'
+    plugins:
+      - ecr#v2.0.0:
+          login: true
+          account-ids: "032379705303"
+      - docker#v3.5.0:
+          image: "032379705303.dkr.ecr.us-east-1.amazonaws.com/deploytools:2020.03"
+          propagate-environment: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,7 +18,7 @@ steps:
   - label: ":s3:"
     command: ".buildkite/steps/upload-to-s3.sh"
     agents:
-      queue: "deploy-legacy"
+      queue: "deploy"
 
   - wait
   - name: ":pipeline:"

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo '--- Getting credentials from SSM'
+export GITHUB_RELEASE_ACCESS_TOKEN=$(aws ssm get-parameter --name /pipelines/buildkite-agent-scaler/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
+
 if [[ "$GITHUB_RELEASE_ACCESS_TOKEN" == "" ]]; then
   echo "Error: Missing \$GITHUB_RELEASE_ACCESS_TOKEN"
   exit 1


### PR DESCRIPTION
The "deploy-legacy" queue is deprecated, and we're slowly moving steps off it.

The agents processing the "deploy" queue are an elastic stack, and the awscli is available. It's likely we'll need to update some IAM roles used by those agents, but we do that elsewhere.

One of the steps also uses the github-release tool, which isn't available on the agents. We can use the deploytools image (via a buildkite plugin) to get it though.

github-release also requires a github API token. On the old agents that was set in an agent hook, but now we need to read it from SSM.