### PR TITLE
Client.queryMetrics: eliminate unnecessary local var indirection

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -85,11 +85,9 @@ func (c *Client) queryMetrics(into interface{}) (pollDuration time.Duration, err
 	if err != nil {
 		return time.Duration(0), err
 	}
-
-	method := http.MethodGet
 	endpoint.Path += "/metrics"
 
-	req, err := http.NewRequest(method, endpoint.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return time.Duration(0), err
 	}
@@ -103,7 +101,7 @@ func (c *Client) queryMetrics(into interface{}) (pollDuration time.Duration, err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return time.Duration(0), fmt.Errorf("%s %s: %s", method, endpoint, res.Status)
+		return time.Duration(0), fmt.Errorf("%s %s: %s", req.Method, endpoint, res.Status)
 	}
 
 	// Check if we get a poll duration header from server


### PR DESCRIPTION
Trivial refactor — I was looking at #23 and hated the way I introduced a local var for the HTTP method. This PR passes the `http.MethodGet` const directly to the request, and then references `http.Request.Method` as source of truth to build an error message.