### PR TITLE
Build with golang 1.15, was 1.12

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,10 +3,8 @@ steps:
     command: ".buildkite/steps/tests.sh"
     plugins:
       - docker#v3.1.0:
-          image: "golang:1.12"
+          image: "golang:1.15"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
-          environment:
-            - GO111MODULE=off
 
   - wait
   - name: ":lambda:"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lambda/handler: lambda/main.go
 		--volume go-module-cache:/go/pkg/mod \
 		--volume $(PWD):/go/src/github.com/buildkite/buildkite-agent-scaler \
 		--workdir /go/src/github.com/buildkite/buildkite-agent-scaler \
-		--rm golang:1.12 \
+		--rm golang:1.15 \
 		go build -ldflags="$(LD_FLAGS)" -o ./lambda/handler ./lambda
 	chmod +x lambda/handler
 


### PR DESCRIPTION
Use Go 1.15 to run tests in CI and to build the lambda binary.