### PR TITLE
Support more regions

### DIFF
--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -9,17 +9,21 @@ EXTRA_REGIONS=(
   us-east-2
   us-west-1
   us-west-2
+  af-south-1
+  ap-east-1
   ap-south-1
   ap-northeast-2
-  ap-southeast-1
-  ap-southeast-2
   ap-northeast-1
+  ap-southeast-2
+  ap-southeast-1
   ca-central-1
   eu-central-1
   eu-west-1
   eu-west-2
+  eu-south-1
   eu-west-3
   eu-north-1
+  me-south-1
   sa-east-1
 )
 

--- a/template.yaml
+++ b/template.yaml
@@ -32,19 +32,26 @@ Parameters:
 
 Mappings:
   LambdaBucket:
-    us-east-1 : { Bucket: "buildkite-lambdas" }
-    us-east-2 : { Bucket: "buildkite-lambdas-us-east-2" }
-    us-west-1 : { Bucket: "buildkite-lambdas-us-west-1" }
-    us-west-2 : { Bucket: "buildkite-lambdas-us-west-2" }
-    eu-west-1 : { Bucket: "buildkite-lambdas-eu-west-1" }
-    eu-west-2 : { Bucket: "buildkite-lambdas-eu-west-2" }
-    eu-central-1 : { Bucket: "buildkite-lambdas-eu-central-1" }
-    ap-northeast-1 : { Bucket: "buildkite-lambdas-ap-northeast-1" }
-    ap-northeast-2 : { Bucket: "buildkite-lambdas-ap-northeast-2" }
-    ap-southeast-1 : { Bucket: "buildkite-lambdas-ap-southeast-1" }
-    ap-southeast-2 : { Bucket: "buildkite-lambdas-ap-southeast-2" }
-    ap-south-1 : { Bucket: "buildkite-lambdas-ap-south-1" }
-    sa-east-1 : { Bucket: "buildkite-lambdas-sa-east-1" }
+    us-east-1: { Bucket: "buildkite-lambdas" }
+    us-east-2: { Bucket: "buildkite-lambdas-us-east-2" }
+    us-west-1: { Bucket: "buildkite-lambdas-us-west-1" }
+    us-west-2: { Bucket: "buildkite-lambdas-us-west-2" }
+    af-south-1: { Bucket: "buildkite-lambdas-af-south-1" }
+    ap-east-1: { Bucket: "buildkite-lambdas-ap-east-1" }
+    ap-south-1: { Bucket: "buildkite-lambdas-ap-south-1" }
+    ap-northeast-2: { Bucket: "buildkite-lambdas-ap-northeast-2" }
+    ap-northeast-1: { Bucket: "buildkite-lambdas-ap-northeast-1" }
+    ap-southeast-2: { Bucket: "buildkite-lambdas-ap-southeast-2" }
+    ap-southeast-1: { Bucket: "buildkite-lambdas-ap-southeast-1" }
+    ca-central-1: { Bucket: "buildkite-lambdas-ca-central-1" }
+    eu-central-1: { Bucket: "buildkite-lambdas-eu-central-1" }
+    eu-west-1: { Bucket: "buildkite-lambdas-eu-west-1" }
+    eu-west-2: { Bucket: "buildkite-lambdas-eu-west-2" }
+    eu-south-1: { Bucket: "buildkite-lambdas-eu-south-1" }
+    eu-west-3: { Bucket: "buildkite-lambdas-eu-west-3" }
+    eu-north-1: { Bucket: "buildkite-lambdas-eu-north-1" }
+    me-south-1: { Bucket: "buildkite-lambdas-me-south-1" }
+    sa-east-1: { Bucket: "buildkite-lambdas-sa-east-1" }
 
 Resources:
   AutoscalingLambdaExecutionRole:


### PR DESCRIPTION
New: af-south-1, ap-east-1. ca-central-1,  eu-south-1, eu-west-3, eu-north-1, me-south-1

Related: https://github.com/buildkite/elastic-ci-stack-for-aws/pull/718