### PR TITLE
Avoid scale out over max and scale in under min

### DIFF
--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -229,10 +229,10 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 	if err != nil {
 		return metrics.PollDuration, err
 	}
-	desiredMax := math.Min(current.MaxSize, desired)
-	log.Printf("Scaling OUT 📈 to %d instances (currently %d)", desiredMax, current.DesiredCount)
+	desiredSafe := math.Min(current.MaxSize, desired)
+	log.Printf("Scaling OUT 📈 to %d instances (currently %d)", desiredSafe, current.DesiredCount)
 
-	if err := s.setDesiredCapacity(desiredMax); err != nil {
+	if err := s.setDesiredCapacity(desiredSafe); err != nil {
 		return err
 	}
 

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -111,6 +111,19 @@ func TestScalingOutWithoutError(t *testing.T) {
 			currentDesiredCapacity:  11,
 			expectedDesiredCapacity: 12,
 		},
+		// Scale-out with a factor too large
+		{
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				ScaleOutParams: ScaleParams{
+					Factor: 500.0,
+				},
+			},
+			expectedDesiredCapacity: 100.0,
+		},
 		// Cool-down period is enforced
 		{
 			metrics: buildkite.AgentMetrics{


### PR DESCRIPTION
We verified this works on a real pipeline using stack built from this PR.

<img width="914" alt="スクリーンショット 2020-10-19 11 14 47" src="https://user-images.githubusercontent.com/1000669/96394721-a9e9c500-11fd-11eb-96c0-06fe0093b6de.png">

Closes #34.