### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.0.2](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.0.1...v1.0.2) (2020-10-19)
+
+* Respect Auto Scaling Group MaxSize and MinSize [#37](https://github.com/buildkite/buildkite-agent-scaler/pull/37) ([nitrocode](https://github.com/nitrocode))
+* Support 6 more regions: af-south-1, ap-east-1. ca-central-1, eu-south-1, eu-west-3, eu-north-1, me-south-1 [#33](https://github.com/buildkite/buildkite-agent-scaler/pull/33) ([JuanitoFatas](https://github.com/JuanitoFatas))
+
 ## [v1.0.1](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.0.0...v1.0.1) (2019-11-27)
 
 * Handle HTTP errors from metrics API [#23](https://github.com/buildkite/buildkite-agent-scaler/pull/23) ([pda](https://github.com/pda))

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.0.1"
+const Version = "1.0.2"
 
 // The build number
 var Build string


### PR DESCRIPTION
- [x] Bump version
- [x] Add changelog for v1.0.2 ([Full Changes](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.0.1...master))
 Notable changes are #37 and #33.

<kbd>[Preview Changelog](https://github.com/buildkite/buildkite-agent-scaler/blob/v102/CHANGELOG.md#v102-2020-10-19)</kbd>