### PR TITLE
Relative scaling calculation

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -40,6 +40,7 @@ type AgentMetrics struct {
 	WaitingJobs   int64
 	IdleAgents    int64
 	BusyAgents    int64
+	TotalAgents   int64
 }
 
 func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
@@ -81,6 +82,7 @@ func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
 	if queue, exists := resp.Agents.Queues[queue]; exists {
 		metrics.IdleAgents = queue.Idle
 		metrics.BusyAgents = queue.Busy
+		metrics.TotalAgents = queue.Total
 	}
 
 	if queue, exists := resp.Jobs.Queues[queue]; exists {

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -38,6 +38,8 @@ type AgentMetrics struct {
 	RunningJobs   int64
 	PollDuration  time.Duration
 	WaitingJobs   int64
+	IdleAgents    int64
+	BusyAgents    int64
 }
 
 func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
@@ -47,6 +49,13 @@ func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
 		Organization struct {
 			Slug string `json:"slug"`
 		} `json:"organization"`
+		Agents struct {
+			Queues map[string]struct {
+				Busy  int64 `json:"busy"`
+				Idle  int64 `json:"idle"`
+				Total int64 `json:"total"`
+			} `json:"queues"`
+		} `json:"agents"`
 		Jobs struct {
 			Queues map[string]struct {
 				Scheduled int64 `json:"scheduled"`
@@ -68,6 +77,11 @@ func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
 	metrics.OrgSlug = resp.Organization.Slug
 	metrics.Queue = queue
 	metrics.PollDuration = pollDuration
+
+	if queue, exists := resp.Agents.Queues[queue]; exists {
+		metrics.IdleAgents = queue.Idle
+		metrics.BusyAgents = queue.Busy
+	}
 
 	if queue, exists := resp.Jobs.Queues[queue]; exists {
 		metrics.ScheduledJobs = queue.Scheduled

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -170,11 +170,6 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				params.ScaleOutParams.Disable = true
 			}
 
-			if m := os.Getenv(`RELATIVE_SCALING`); m == `true` || m == `1` {
-				log.Printf("Using relative scaling calculation")
-				params.RelativeScaling = true
-			}
-
 			scaler, err := scaler.NewScaler(client, params)
 			if err != nil {
 				log.Fatal(err)

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -170,6 +170,11 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				params.ScaleOutParams.Disable = true
 			}
 
+			if m := os.Getenv(`RELATIVE_SCALING`); m == `true` || m == `1` {
+				log.Printf("Using relative scaling calculation")
+				params.RelativeScaling = true
+			}
+
 			scaler, err := scaler.NewScaler(client, params)
 			if err != nil {
 				log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ func main() {
 		includeWaiting      = flag.Bool("include-waiting", false, "Whether to include jobs behind a wait step for scaling")
 
 		// scale in/out params
-		relativeScaling = flag.Bool("relative-scaling", false, "Whether to use relative scaling calculation")
 		scaleInFactor   = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
 		scaleOutFactor  = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
@@ -50,7 +49,6 @@ func main() {
 		IncludeWaiting:           *includeWaiting,
 		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
 		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
-		RelativeScaling:          *relativeScaling,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -22,8 +22,9 @@ func main() {
 		includeWaiting      = flag.Bool("include-waiting", false, "Whether to include jobs behind a wait step for scaling")
 
 		// scale in/out params
-		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
-		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
+		relativeScaling = flag.Bool("relative-scaling", false, "Whether to use relative scaling calculation")
+		scaleInFactor   = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
+		scaleOutFactor  = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
 		// general params
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
@@ -49,6 +50,7 @@ func main() {
 		IncludeWaiting:           *includeWaiting,
 		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
 		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
+		RelativeScaling:          *relativeScaling,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -41,8 +41,6 @@ type Scaler struct {
 		Publish(orgSlug, queue string, metrics map[string]int64) error
 	}
 	scaling ScalingCalculator
-	//includeWaiting    bool
-	//agentsPerInstance int
 	scaleInParams  ScaleParams
 	scaleOutParams ScaleParams
 }

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -26,7 +26,6 @@ type Params struct {
 	IncludeWaiting           bool
 	ScaleInParams            ScaleParams
 	ScaleOutParams           ScaleParams
-	RelativeScaling          bool
 }
 
 type Scaler struct {
@@ -55,16 +54,9 @@ func NewScaler(client *buildkite.Client, params Params) (*Scaler, error) {
 		scaleOutParams: params.ScaleOutParams,
 	}
 
-	if params.RelativeScaling {
-		scaler.scaling = &RelativeScaling{
-			includeWaiting:    params.IncludeWaiting,
-			agentsPerInstance: params.AgentsPerInstance,
-		}
-	} else {
-		scaler.scaling = &AbsoluteScaling{
-			includeWaiting:    params.IncludeWaiting,
-			agentsPerInstance: params.AgentsPerInstance,
-		}
+	scaler.scaling = ScalingCalculator{
+		includeWaiting:    params.IncludeWaiting,
+		agentsPerInstance: params.AgentsPerInstance,
 	}
 
 	if params.DryRun {

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -26,6 +26,7 @@ type Params struct {
 	IncludeWaiting           bool
 	ScaleInParams            ScaleParams
 	ScaleOutParams           ScaleParams
+	RelativeScaling          bool
 }
 
 type Scaler struct {
@@ -39,10 +40,11 @@ type Scaler struct {
 	metrics interface {
 		Publish(orgSlug, queue string, metrics map[string]int64) error
 	}
-	includeWaiting    bool
-	agentsPerInstance int
-	scaleInParams     ScaleParams
-	scaleOutParams    ScaleParams
+	scaling ScalingCalculator
+	//includeWaiting    bool
+	//agentsPerInstance int
+	scaleInParams  ScaleParams
+	scaleOutParams ScaleParams
 }
 
 func NewScaler(client *buildkite.Client, params Params) (*Scaler, error) {
@@ -51,10 +53,20 @@ func NewScaler(client *buildkite.Client, params Params) (*Scaler, error) {
 			client: client,
 			queue:  params.BuildkiteQueue,
 		},
-		includeWaiting:    params.IncludeWaiting,
-		agentsPerInstance: params.AgentsPerInstance,
-		scaleInParams:     params.ScaleInParams,
-		scaleOutParams:    params.ScaleOutParams,
+		scaleInParams:  params.ScaleInParams,
+		scaleOutParams: params.ScaleOutParams,
+	}
+
+	if params.RelativeScaling {
+		scaler.scaling = &RelativeScaling{
+			includeWaiting:    params.IncludeWaiting,
+			agentsPerInstance: params.AgentsPerInstance,
+		}
+	} else {
+		scaler.scaling = &AbsoluteScaling{
+			includeWaiting:    params.IncludeWaiting,
+			agentsPerInstance: params.AgentsPerInstance,
+		}
 	}
 
 	if params.DryRun {
@@ -93,45 +105,30 @@ func (s *Scaler) Run() (time.Duration, error) {
 		}
 	}
 
-	count := metrics.ScheduledJobs
-
-	// If waiting jobs are greater than running jobs then optionally
-	// use waiting jobs for scaling so that we have instances booted
-	// by the time we get to them. This is a gamble, as if the instances
-	// scale down before the jobs get scheduled, it's a huge waste.
-	if s.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
-		count += metrics.WaitingJobs
-	} else {
-		count += metrics.RunningJobs
-	}
-
-	var desired int64
-	if count > 0 {
-		desired = int64(math.Ceil(float64(count) / float64(s.agentsPerInstance)))
-	}
-
-	current, err := s.autoscaling.Describe()
+	asg, err := s.autoscaling.Describe()
 	if err != nil {
 		return metrics.PollDuration, err
 	}
 
-	if desired > current.MaxSize {
-		log.Printf("⚠️  Desired count exceed MaxSize, capping at %d", current.MaxSize)
-		desired = current.MaxSize
-	} else if desired < current.MinSize {
-		log.Printf("⚠️  Desired count is less than MinSize, capping at %d", current.MinSize)
-		desired = current.MinSize
+	desired := s.scaling.DesiredCount(&metrics, &asg)
+
+	if desired > asg.MaxSize {
+		log.Printf("⚠️  Desired count exceed MaxSize, capping at %d", asg.MaxSize)
+		desired = asg.MaxSize
+	} else if desired < asg.MinSize {
+		log.Printf("⚠️  Desired count is less than MinSize, capping at %d", asg.MinSize)
+		desired = asg.MinSize
 	}
 
-	if desired > current.DesiredCount {
-		return metrics.PollDuration, s.scaleOut(desired, current)
+	if desired > asg.DesiredCount {
+		return metrics.PollDuration, s.scaleOut(desired, asg)
 	}
 
-	if current.DesiredCount > desired {
-		return metrics.PollDuration, s.scaleIn(desired, current)
+	if asg.DesiredCount > desired {
+		return metrics.PollDuration, s.scaleIn(desired, asg)
 	}
 
-	log.Printf("No scaling required, currently %d", current.DesiredCount)
+	log.Printf("No scaling required, currently %d", asg.DesiredCount)
 	return metrics.PollDuration, nil
 }
 
@@ -209,6 +206,7 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 
 	// Calculate the change in the desired count, will be positive
 	change := desired - current.DesiredCount
+	log.Printf("DEBUG: change=(%d-%d)=%d", desired, current.DesiredCount, change)
 
 	// Apply scaling factor if one is given
 	if s.scaleOutParams.Factor != 0 {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -214,7 +214,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 			expectedDesiredCapacity: 1,
 		},
 	} {
-		t.Run("absolute", func(t *testing.T) {
+		t.Run("", func(t *testing.T) {
 			asg := &asgTestDriver{
 				desiredCapacity: tc.currentDesiredCapacity,
 			}
@@ -222,57 +222,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 				autoscaling:    asg,
 				bk:             &buildkiteTestDriver{metrics: tc.metrics},
 				scaleOutParams: tc.params.ScaleOutParams,
-				scaling: &AbsoluteScaling{
-					includeWaiting:    tc.params.IncludeWaiting,
-					agentsPerInstance: tc.params.AgentsPerInstance,
-				},
-			}
-
-			if _, err := s.Run(); err != nil {
-				t.Fatal(err)
-			}
-
-			if asg.desiredCapacity != tc.expectedDesiredCapacity {
-				t.Fatalf("Expected desired capacity of %d, got %d",
-					tc.expectedDesiredCapacity, asg.desiredCapacity,
-				)
-			}
-		})
-
-		t.Run("relative", func(t *testing.T) {
-			asg := &asgTestDriver{
-				desiredCapacity: tc.currentDesiredCapacity,
-			}
-			s := Scaler{
-				autoscaling:    asg,
-				bk:             &buildkiteTestDriver{metrics: tc.metrics},
-				scaleOutParams: tc.params.ScaleOutParams,
-				scaling: &RelativeScaling{
-					includeWaiting:    tc.params.IncludeWaiting,
-					agentsPerInstance: tc.params.AgentsPerInstance,
-				},
-			}
-
-			if _, err := s.Run(); err != nil {
-				t.Fatal(err)
-			}
-
-			if asg.desiredCapacity != tc.expectedDesiredCapacity {
-				t.Fatalf("Expected desired capacity of %d, got %d",
-					tc.expectedDesiredCapacity, asg.desiredCapacity,
-				)
-			}
-		})
-
-		t.Run("hybrid", func(t *testing.T) {
-			asg := &asgTestDriver{
-				desiredCapacity: tc.currentDesiredCapacity,
-			}
-			s := Scaler{
-				autoscaling:    asg,
-				bk:             &buildkiteTestDriver{metrics: tc.metrics},
-				scaleOutParams: tc.params.ScaleOutParams,
-				scaling: &HybridScaling{
+				scaling: ScalingCalculator{
 					includeWaiting:    tc.params.IncludeWaiting,
 					agentsPerInstance: tc.params.AgentsPerInstance,
 				},
@@ -384,57 +334,7 @@ func TestScalingInWithoutError(t *testing.T) {
 			s := Scaler{
 				autoscaling: asg,
 				bk:          &buildkiteTestDriver{metrics: tc.metrics},
-				scaling: &AbsoluteScaling{
-					includeWaiting:    tc.params.IncludeWaiting,
-					agentsPerInstance: tc.params.AgentsPerInstance,
-				},
-				scaleInParams: tc.params.ScaleInParams,
-			}
-
-			if _, err := s.Run(); err != nil {
-				t.Fatal(err)
-			}
-
-			if asg.desiredCapacity != tc.expectedDesiredCapacity {
-				t.Fatalf("Expected desired capacity of %d, got %d",
-					tc.expectedDesiredCapacity, asg.desiredCapacity,
-				)
-			}
-		})
-
-		t.Run("relative", func(t *testing.T) {
-			asg := &asgTestDriver{
-				desiredCapacity: tc.currentDesiredCapacity,
-			}
-			s := Scaler{
-				autoscaling: asg,
-				bk:          &buildkiteTestDriver{metrics: tc.metrics},
-				scaling: &RelativeScaling{
-					includeWaiting:    tc.params.IncludeWaiting,
-					agentsPerInstance: tc.params.AgentsPerInstance,
-				},
-				scaleInParams: tc.params.ScaleInParams,
-			}
-
-			if _, err := s.Run(); err != nil {
-				t.Fatal(err)
-			}
-
-			if asg.desiredCapacity != tc.expectedDesiredCapacity {
-				t.Fatalf("Expected desired capacity of %d, got %d",
-					tc.expectedDesiredCapacity, asg.desiredCapacity,
-				)
-			}
-		})
-
-		t.Run("hybrid", func(t *testing.T) {
-			asg := &asgTestDriver{
-				desiredCapacity: tc.currentDesiredCapacity,
-			}
-			s := Scaler{
-				autoscaling: asg,
-				bk:          &buildkiteTestDriver{metrics: tc.metrics},
-				scaling: &HybridScaling{
+				scaling: ScalingCalculator{
 					includeWaiting:    tc.params.IncludeWaiting,
 					agentsPerInstance: tc.params.AgentsPerInstance,
 				},

--- a/scaler/scaling_calculator.go
+++ b/scaler/scaling_calculator.go
@@ -1,0 +1,71 @@
+package scaler
+
+import (
+	"math"
+
+	"github.com/buildkite/buildkite-agent-scaler/buildkite"
+)
+
+type ScalingCalculator interface {
+	DesiredCount(*buildkite.AgentMetrics, *AutoscaleGroupDetails) int64
+}
+
+type AbsoluteScaling struct {
+	includeWaiting    bool
+	agentsPerInstance int
+}
+
+func (as *AbsoluteScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
+	count := metrics.ScheduledJobs
+
+	// If waiting jobs are greater than running jobs then optionally
+	// use waiting jobs for scaling so that we have instances booted
+	// by the time we get to them. This is a gamble, as if the instances
+	// scale down before the jobs get scheduled, it's a huge waste.
+	if as.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
+		count += metrics.WaitingJobs
+	} else {
+		count += metrics.RunningJobs
+	}
+
+	var desired int64
+	if count > 0 {
+		desired = int64(math.Ceil(float64(count) / float64(as.agentsPerInstance)))
+	}
+
+	return desired
+}
+
+type RelativeScaling struct {
+	includeWaiting    bool
+	agentsPerInstance int
+}
+
+func (rs *RelativeScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
+	jobCount := metrics.ScheduledJobs
+
+	// If waiting jobs are greater than running jobs then optionally
+	// use waiting jobs for scaling so that we have instances booted
+	// by the time we get to them. This is a gamble, as if the instances
+	// scale down before the jobs get scheduled, it's a huge waste.
+	if rs.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
+		jobCount += metrics.WaitingJobs - metrics.RunningJobs
+	}
+
+	agentsAvailable := metrics.IdleAgents + (asg.Pending * int64(rs.agentsPerInstance))
+	agentsRequired := jobCount - agentsAvailable
+
+	desiredCount := asg.DesiredCount
+
+	if agentsRequired > 0 {
+		delta := int64(math.Ceil(float64(agentsRequired) / float64(rs.agentsPerInstance)))
+		desiredCount = asg.DesiredCount + delta
+	}
+
+	if agentsRequired < 0 {
+		delta := int64(math.Ceil(float64(agentsRequired) / float64(rs.agentsPerInstance)))
+		desiredCount = asg.DesiredCount + delta
+	}
+
+	return desiredCount
+}

--- a/scaler/scaling_calculator.go
+++ b/scaler/scaling_calculator.go
@@ -6,83 +6,16 @@ import (
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
 
-type ScalingCalculator interface {
-	DesiredCount(*buildkite.AgentMetrics, *AutoscaleGroupDetails) int64
-}
-
-type AbsoluteScaling struct {
+type ScalingCalculator struct {
 	includeWaiting    bool
 	agentsPerInstance int
 }
 
-func (sc *AbsoluteScaling) perInstance(count int64) int64 {
+func (sc *ScalingCalculator) perInstance(count int64) int64 {
 	return int64(math.Ceil(float64(count) / float64(sc.agentsPerInstance)))
 }
 
-func (sc *AbsoluteScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
-	count := metrics.ScheduledJobs
-
-	// If waiting jobs are greater than running jobs then optionally
-	// use waiting jobs for scaling so that we have instances booted
-	// by the time we get to them. This is a gamble, as if the instances
-	// scale down before the jobs get scheduled, it's a huge waste.
-	if sc.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
-		count += metrics.WaitingJobs
-	} else {
-		count += metrics.RunningJobs
-	}
-
-	var desired int64
-	if count > 0 {
-		desired = sc.perInstance(count)
-	}
-
-	return desired
-}
-
-type RelativeScaling struct {
-	includeWaiting    bool
-	agentsPerInstance int
-}
-
-func (sc *RelativeScaling) perInstance(count int64) int64 {
-	return int64(math.Ceil(float64(count) / float64(sc.agentsPerInstance)))
-}
-
-func (sc *RelativeScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
-	jobCount := metrics.ScheduledJobs
-
-	// If waiting jobs are greater than running jobs then optionally
-	// use waiting jobs for scaling so that we have instances booted
-	// by the time we get to them. This is a gamble, as if the instances
-	// scale down before the jobs get scheduled, it's a huge waste.
-	if sc.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
-		jobCount += metrics.WaitingJobs - metrics.RunningJobs
-	}
-
-	agentsAvailable := metrics.IdleAgents + (asg.Pending * int64(sc.agentsPerInstance))
-	agentsRequired := jobCount - agentsAvailable
-
-	desiredCount := asg.DesiredCount
-
-	if agentsRequired != 0 {
-		delta := sc.perInstance(agentsRequired)
-		desiredCount = asg.DesiredCount + delta
-	}
-
-	return desiredCount
-}
-
-type HybridScaling struct {
-	includeWaiting    bool
-	agentsPerInstance int
-}
-
-func (sc *HybridScaling) perInstance(count int64) int64 {
-	return int64(math.Ceil(float64(count) / float64(sc.agentsPerInstance)))
-}
-
-func (sc *HybridScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
+func (sc *ScalingCalculator) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
 	agentsRequired := metrics.ScheduledJobs
 
 	// If waiting jobs are greater than running jobs then optionally

--- a/scaler/scaling_calculator.go
+++ b/scaler/scaling_calculator.go
@@ -34,13 +34,23 @@ func (sc *ScalingCalculator) DesiredCount(metrics *buildkite.AgentMetrics, asg *
 	}
 
 	// If there are less agents registered than we'd expect based on the size
-	// of the autoscaling group, then there may be instances not accepting jobs:
-	// possibly because they are in the process of draining jobs for a
-	// graceful shutdown. In this case, we should expand the asg further to accommodate.
-	anticipated := (asg.DesiredCount - asg.Pending) * int64(sc.agentsPerInstance)
-	shortfall := anticipated - metrics.TotalAgents
-	if shortfall > 0 {
-		desired += sc.perInstance(shortfall)
+	// of the autoscaling group, then there may be instances not accepting
+	// jobs: possibly because they are in the process of draining jobs for a
+	// graceful shutdown. In this case, we should expand the asg further to
+	// accommodate.
+	//
+	// Currently, restrict this behaviour to only occur when there are fewer
+	// than 2 instances (worth of agents) running. This will prevent any
+	// unexpected behaviour in large scaling groups. Since the effects of an
+	// instance not accepting jobs are more pronounced when there are fewer
+	// instances, this should cover the worst case scenario(s) where there may
+	// not be any instances accepting jobs.
+	if metrics.TotalAgents < int64(sc.agentsPerInstance) * 2 {
+		anticipated := (asg.DesiredCount - asg.Pending) * int64(sc.agentsPerInstance)
+		shortfall := anticipated - metrics.TotalAgents
+		if shortfall > 0 {
+			desired += sc.perInstance(shortfall)
+		}
 	}
 
 	return desired

--- a/scaler/scaling_calculator.go
+++ b/scaler/scaling_calculator.go
@@ -15,14 +15,18 @@ type AbsoluteScaling struct {
 	agentsPerInstance int
 }
 
-func (as *AbsoluteScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
+func (sc *AbsoluteScaling) perInstance(count int64) int64 {
+	return int64(math.Ceil(float64(count) / float64(sc.agentsPerInstance)))
+}
+
+func (sc *AbsoluteScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
 	count := metrics.ScheduledJobs
 
 	// If waiting jobs are greater than running jobs then optionally
 	// use waiting jobs for scaling so that we have instances booted
 	// by the time we get to them. This is a gamble, as if the instances
 	// scale down before the jobs get scheduled, it's a huge waste.
-	if as.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
+	if sc.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
 		count += metrics.WaitingJobs
 	} else {
 		count += metrics.RunningJobs
@@ -30,7 +34,7 @@ func (as *AbsoluteScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *Au
 
 	var desired int64
 	if count > 0 {
-		desired = int64(math.Ceil(float64(count) / float64(as.agentsPerInstance)))
+		desired = sc.perInstance(count)
 	}
 
 	return desired
@@ -41,31 +45,70 @@ type RelativeScaling struct {
 	agentsPerInstance int
 }
 
-func (rs *RelativeScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
+func (sc *RelativeScaling) perInstance(count int64) int64 {
+	return int64(math.Ceil(float64(count) / float64(sc.agentsPerInstance)))
+}
+
+func (sc *RelativeScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
 	jobCount := metrics.ScheduledJobs
 
 	// If waiting jobs are greater than running jobs then optionally
 	// use waiting jobs for scaling so that we have instances booted
 	// by the time we get to them. This is a gamble, as if the instances
 	// scale down before the jobs get scheduled, it's a huge waste.
-	if rs.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
+	if sc.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
 		jobCount += metrics.WaitingJobs - metrics.RunningJobs
 	}
 
-	agentsAvailable := metrics.IdleAgents + (asg.Pending * int64(rs.agentsPerInstance))
+	agentsAvailable := metrics.IdleAgents + (asg.Pending * int64(sc.agentsPerInstance))
 	agentsRequired := jobCount - agentsAvailable
 
 	desiredCount := asg.DesiredCount
 
-	if agentsRequired > 0 {
-		delta := int64(math.Ceil(float64(agentsRequired) / float64(rs.agentsPerInstance)))
-		desiredCount = asg.DesiredCount + delta
-	}
-
-	if agentsRequired < 0 {
-		delta := int64(math.Ceil(float64(agentsRequired) / float64(rs.agentsPerInstance)))
+	if agentsRequired != 0 {
+		delta := sc.perInstance(agentsRequired)
 		desiredCount = asg.DesiredCount + delta
 	}
 
 	return desiredCount
+}
+
+type HybridScaling struct {
+	includeWaiting    bool
+	agentsPerInstance int
+}
+
+func (sc *HybridScaling) perInstance(count int64) int64 {
+	return int64(math.Ceil(float64(count) / float64(sc.agentsPerInstance)))
+}
+
+func (sc *HybridScaling) DesiredCount(metrics *buildkite.AgentMetrics, asg *AutoscaleGroupDetails) int64 {
+	agentsRequired := metrics.ScheduledJobs
+
+	// If waiting jobs are greater than running jobs then optionally
+	// use waiting jobs for scaling so that we have instances booted
+	// by the time we get to them. This is a gamble, as if the instances
+	// scale down before the jobs get scheduled, it's a huge waste.
+	if sc.includeWaiting && metrics.WaitingJobs > metrics.RunningJobs {
+		agentsRequired += metrics.WaitingJobs
+	} else {
+		agentsRequired += metrics.RunningJobs
+	}
+
+	var desired int64
+	if agentsRequired > 0 {
+		desired = sc.perInstance(agentsRequired)
+	}
+
+	// If there are less agents registered than we'd expect based on the size
+	// of the autoscaling group, then there may be instances not accepting jobs:
+	// possibly because they are in the process of draining jobs for a
+	// graceful shutdown. In this case, we should expand the asg further to accommodate.
+	anticipated := (asg.DesiredCount - asg.Pending) * int64(sc.agentsPerInstance)
+	shortfall := anticipated - metrics.TotalAgents
+	if shortfall > 0 {
+		desired += sc.perInstance(shortfall)
+	}
+
+	return desired
 }


### PR DESCRIPTION
Proposed solution to #39. It's fresh off the keyboard, and I haven't had a chance to set up a test lab to verify it does what I expect in the real world yet.

Implements an (opt-in) alternative scaling calculation using relative numbers. i.e. N _more_ instances requires as opposed to N _total_ instances required.

This should work better in cases where not all agents on an instance are running or accepting jobs. For example, while waiting for (potentially long-running) jobs to complete during a graceful shutdown.