### PR TITLE
Publish Agent Metrics to Cloudwatch along with existing Job Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ See the [forum post](https://forum.buildkite.community/t/experimental-lambda-bas
 
 ## Publishing Cloudwatch Metrics
 
-The scaler collects it's own metrics and doesn't require the [buildkite-agent-metrics][]. It supports optionally publishing the metrics it collects back to Cloudwatch, although it only supports a subset of the metrics that the [buildkite-agent-metrics][] binary collects:
+The scaler collects it's own metrics and doesn't require the [buildkite-agent-metrics][].  
+It supports optionally publishing the metrics it collects back to Cloudwatch.  
 
+Binary collects:
 * Buildkite > (Org, Queue) > `ScheduledJobsCount`
-* Buildkite > (Org, Queue) > `RunningJobCount`
+* Buildkite > (Org, Queue) > `RunningJobsCount`
+* Buildkite > (Org, Queue) > `WaitingJobsCount`
+* Buildkite > (Org, Queue) > `IdleAgentCount`
+* Buildkite > (Org, Queue) > `BusyAgentCount`
+* Buildkite > (Org, Queue) > `TotalAgentCount`
 
 ## Running as an AWS Lambda
 

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -91,8 +91,15 @@ func (c *Client) GetAgentMetrics(queue string) (AgentMetrics, error) {
 		metrics.WaitingJobs = queue.Waiting
 	}
 
-	log.Printf("↳ Got scheduled=%d, running=%d, waiting=%d (took %v)",
-		metrics.ScheduledJobs, metrics.RunningJobs, metrics.WaitingJobs, queryDuration)
+	log.Printf("↳ Got scheduled=%d, running=%d, waiting=%d, idleAgents=%d, busyAgents=%d, totalAgents=%d (took %v)",
+		metrics.ScheduledJobs,
+		metrics.RunningJobs,
+		metrics.WaitingJobs,
+		metrics.IdleAgents,
+		metrics.BusyAgents,
+		metrics.TotalAgents,
+		queryDuration)
+		
 	return metrics, nil
 }
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -89,6 +89,10 @@ func (s *Scaler) Run() (time.Duration, error) {
 			`ScheduledJobsCount`: metrics.ScheduledJobs,
 			`RunningJobsCount`:   metrics.RunningJobs,
 			`WaitingJobsCount`:   metrics.WaitingJobs,
+
+			`IdleAgentCount`:   metrics.IdleAgents,
+			`BusyAgentCount`:   metrics.BusyAgents,
+			`TotalAgentCount`:   metrics.TotalAgents,
 		})
 		if err != nil {
 			return metrics.PollDuration, err


### PR DESCRIPTION
This includes the Agent Metrics and sends it along to Cloudwatch.
The metrics were already being collected and have now just been added to the logging and publishing functions

The metrics added:
- IdleAgentCount
- BusyAgentCount
- TotalAgentCount

The main reason to add these is it is possible to scale up the agents when there are none free. This helps us reduce deployment time by having a warm agent running and waiting for the new job (Scale when no free agents), while still getting the useful downscale on idle events.

I have tested that the metrics are there, but I can't get the aws-vault to connect to the ASG, etc to test metrics collection
`2021/05/05 12:43:42 Collecting agent metrics for queue "default"`
`2021/05/05 12:43:43 ↳ Got scheduled=0, running=0, waiting=0, idleAgents=3, busyAgents=0, totalAgents=3 (took 1.102213142s)`