### PR TITLE
Revert agent shortfall scaling

### DIFF
--- a/scaler/scaling_calculator.go
+++ b/scaler/scaling_calculator.go
@@ -33,25 +33,5 @@ func (sc *ScalingCalculator) DesiredCount(metrics *buildkite.AgentMetrics, asg *
 		desired = sc.perInstance(agentsRequired)
 	}
 
-	// If there are less agents registered than we'd expect based on the size
-	// of the autoscaling group, then there may be instances not accepting
-	// jobs: possibly because they are in the process of draining jobs for a
-	// graceful shutdown. In this case, we should expand the asg further to
-	// accommodate.
-	//
-	// Currently, restrict this behaviour to only occur when there are fewer
-	// than 2 instances (worth of agents) running. This will prevent any
-	// unexpected behaviour in large scaling groups. Since the effects of an
-	// instance not accepting jobs are more pronounced when there are fewer
-	// instances, this should cover the worst case scenario(s) where there may
-	// not be any instances accepting jobs.
-	if metrics.TotalAgents < int64(sc.agentsPerInstance) * 2 {
-		anticipated := (asg.DesiredCount - asg.Pending) * int64(sc.agentsPerInstance)
-		shortfall := anticipated - metrics.TotalAgents
-		if shortfall > 0 {
-			desired += sc.perInstance(shortfall)
-		}
-	}
-
 	return desired
 }


### PR DESCRIPTION
This was added in #40 but is causing issues where the stack will scale too aggressively.

There is a race condition between an instance being added to the desired count in the ASG and the buildkite agents being registered while the cloud-init bring up is completed.

One way to handle this might be to add a boot time lifecycle hook, to hold the instance in the ASG `Pending` state until the Buildkite agents are booted and can be reliably counted. However, in the short term I think we need to revert this behaviour and roll out an updated stack for customers incurring undesirable additional cost.

I’ve left the additional refactoring in place from that pull request and have just removed the change in the calculation.