### PR TITLE
Use AWS shared credentials config

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,12 +28,21 @@ func main() {
 		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
 		// general params
-		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
+		dryRun       = flag.Bool("dry-run", false, "Whether to just show what would be done")
+		sharedConfig = flag.Bool("aws-shared-config", false, "Whether to enable shared config for the AWS SDK")
 	)
 	flag.Parse()
 
 	// establish an AWS session to be re-used
-	sess := session.New()
+	var sess *session.Session
+
+	if *sharedConfig {
+		sess = session.Must(session.NewSessionWithOptions(session.Options{
+			SharedConfigState: session.SharedConfigEnable,
+		}))
+	} else {
+		sess = session.New()
+	}
 
 	if *ssmTokenKey != "" {
 		token, err := scaler.RetrieveFromParameterStore(sess, *ssmTokenKey)

--- a/main.go
+++ b/main.go
@@ -28,21 +28,14 @@ func main() {
 		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
 		// general params
-		dryRun       = flag.Bool("dry-run", false, "Whether to just show what would be done")
-		sharedConfig = flag.Bool("aws-shared-config", false, "Whether to enable shared config for the AWS SDK")
+		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
 	)
 	flag.Parse()
 
 	// establish an AWS session to be re-used
-	var sess *session.Session
-
-	if *sharedConfig {
-		sess = session.Must(session.NewSessionWithOptions(session.Options{
-			SharedConfigState: session.SharedConfigEnable,
-		}))
-	} else {
-		sess = session.New()
-	}
+	sess := session.Must(session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	}))
 
 	if *ssmTokenKey != "" {
 		token, err := scaler.RetrieveFromParameterStore(sess, *ssmTokenKey)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 	"github.com/buildkite/buildkite-agent-scaler/scaler"
 )
@@ -23,16 +24,19 @@ func main() {
 		includeWaiting      = flag.Bool("include-waiting", false, "Whether to include jobs behind a wait step for scaling")
 
 		// scale in/out params
-		scaleInFactor   = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
-		scaleOutFactor  = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
+		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
+		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
 		// general params
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
 	)
 	flag.Parse()
 
+	// establish an AWS session to be re-used
+	sess := session.New()
+
 	if *ssmTokenKey != "" {
-		token, err := scaler.RetrieveFromParameterStore(*ssmTokenKey)
+		token, err := scaler.RetrieveFromParameterStore(sess, *ssmTokenKey)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -41,7 +45,7 @@ func main() {
 
 	client := buildkite.NewClient(*buildkiteAgentToken)
 
-	scaler, err := scaler.NewScaler(client, scaler.Params{
+	scaler, err := scaler.NewScaler(client, sess, scaler.Params{
 		BuildkiteQueue:           *buildkiteQueue,
 		AutoScalingGroupName:     *asgName,
 		AgentsPerInstance:        *agentsPerInstance,
@@ -59,7 +63,7 @@ func main() {
 		log.Printf("Running as a dry-run, no changes will be made")
 	}
 
-	var interval time.Duration = 10 * time.Second;
+	var interval time.Duration = 10 * time.Second
 
 	for {
 		minPollDuration, err := scaler.Run()

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -19,12 +19,13 @@ type AutoscaleGroupDetails struct {
 
 type asgDriver struct {
 	name string
+	sess *session.Session
 }
 
 func (a *asgDriver) Describe() (AutoscaleGroupDetails, error) {
 	log.Printf("Collecting AutoScaling details for ASG %q", a.name)
 
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(a.sess)
 	input := &autoscaling.DescribeAutoScalingGroupsInput{
 		AutoScalingGroupNames: []*string{
 			aws.String(a.name),
@@ -64,7 +65,7 @@ func (a *asgDriver) Describe() (AutoscaleGroupDetails, error) {
 }
 
 func (a *asgDriver) SetDesiredCapacity(count int64) error {
-	svc := autoscaling.New(session.New())
+	svc := autoscaling.New(a.sess)
 	input := &autoscaling.SetDesiredCapacityInput{
 		AutoScalingGroupName: aws.String(a.name),
 		DesiredCapacity:      aws.Int64(count),

--- a/scaler/cloudwatch.go
+++ b/scaler/cloudwatch.go
@@ -14,11 +14,12 @@ const (
 
 // cloudWatchMetricsPublisher sends queue metrics to AWS CloudWatch
 type cloudWatchMetricsPublisher struct {
+	sess *session.Session
 }
 
 // Publish queue metrics to CloudWatch Metrics
 func (cp *cloudWatchMetricsPublisher) Publish(orgSlug, queue string, metrics map[string]int64) error {
-	svc := cloudwatch.New(session.New())
+	svc := cloudwatch.New(cp.sess)
 
 	datum := []*cloudwatch.MetricDatum{}
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
 
@@ -39,12 +40,12 @@ type Scaler struct {
 	metrics interface {
 		Publish(orgSlug, queue string, metrics map[string]int64) error
 	}
-	scaling ScalingCalculator
+	scaling        ScalingCalculator
 	scaleInParams  ScaleParams
 	scaleOutParams ScaleParams
 }
 
-func NewScaler(client *buildkite.Client, params Params) (*Scaler, error) {
+func NewScaler(client *buildkite.Client, sess *session.Session, params Params) (*Scaler, error) {
 	scaler := &Scaler{
 		bk: &buildkiteDriver{
 			client: client,
@@ -68,6 +69,7 @@ func NewScaler(client *buildkite.Client, params Params) (*Scaler, error) {
 	} else {
 		scaler.autoscaling = &asgDriver{
 			name: params.AutoScalingGroupName,
+			sess: sess,
 		}
 
 		if params.PublishCloudWatchMetrics {

--- a/scaler/ssm.go
+++ b/scaler/ssm.go
@@ -6,8 +6,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
-func RetrieveFromParameterStore(key string) (string, error) {
-	ssmClient := ssm.New(session.New())
+func RetrieveFromParameterStore(sess *session.Session, key string) (string, error) {
+	ssmClient := ssm.New(sess)
 	output, err := ssmClient.GetParameter(&ssm.GetParameterInput{
 		Name:           &key,
 		WithDecryption: aws.Bool(true),


### PR DESCRIPTION
This enables shared config checks in the AWS Session SDK for setups that use `~/.aws/credentials`. See https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html

Note that 508764a makes a change where by a single session is used and passed around vs `session.New()` invoked everywhere. It's remotely possible this could break things where creating a new session each time was providing some durability around failures and dropouts unintentionally. I don't think this is likely, as there are internal retry mechanisms in the single session. In fact, I think that it's likely that establishing lots of new sessions could lead to rate-limiting and latency. 