### PR TITLE
Add support for Agent Tokens stored in Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ An AWS Lambda bundle is created and published as part of the build process. The 
 
 It's entrypoint is `handler`, it requires a `go1.x` environment and requires the following env vars:
 
-- `BUILDKITE_AGENT_TOKEN` or `BUILDKITE_AGENT_TOKEN_SSM_KEY`
+- `BUILDKITE_AGENT_TOKEN` or `BUILDKITE_AGENT_TOKEN_SSM_KEY` or `BUILDKITE_AGENT_TOKEN_SM_KEY`
 - `BUILDKITE_QUEUE`
 - `AGENTS_PER_INSTANCE`
 - `ASG_NAME`

--- a/scaler/ssm.go
+++ b/scaler/ssm.go
@@ -1,8 +1,11 @@
 package scaler
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
@@ -17,4 +20,22 @@ func RetrieveFromParameterStore(sess *session.Session, key string) (string, erro
 	}
 
 	return *output.Parameter.Value, nil
+}
+
+func RetrieveFromSecretsManager(sess *session.Session, secretID string) (string, error) {
+	svc := secretsmanager.New(sess)
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretID),
+	}
+
+	result, err := svc.GetSecretValue(input)
+	if err != nil {
+		return "", err
+	}
+
+	if result.SecretString == nil {
+		return "", fmt.Errorf("kms encrypted values not supported")
+	}
+
+	return *result.SecretString, nil
 }


### PR DESCRIPTION
This adds support for accessing Agent Tokens directly in AWS Secrets Manager.

It's arguable that one could just access the secret directly via `/aws/reference/secretsmanager/${SECRET}`. (See https://docs.amazonaws.cn/en_us/systems-manager/latest/userguide/integration-ps-secretsmanager.html).

Presented for discussion. 