### PR TITLE
Set last scale in and out event on autoscaler activity

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -27,7 +27,7 @@ var (
 
 type LastScaleASGResult struct {
 	LastScaleOutActivity *autoscaling.Activity
-    LastScaleInActivity *autoscaling.Activity
+	LastScaleInActivity *autoscaling.Activity
 	Err error
 }
 
@@ -198,8 +198,6 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				)
 			}
 
-			log.Printf("Last scale in event: %s", lastScaleIn)
-			log.Printf("Last scale out event: %s", lastScaleOut)
 			client := buildkite.NewClient(token)
 			params := scaler.Params{
 				BuildkiteQueue:       mustGetEnv(`BUILDKITE_QUEUE`),

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -170,7 +170,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			}
 		}
     case <- asgActivityTimeout:
-        log.Printf("Failed to scale in and out last activity due to %s timeout", asgActivityTimeoutDuration)
+        log.Printf("Failed to get scale in and out last activity due to %s timeout", asgActivityTimeoutDuration)
     }
 
 	for {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -172,7 +172,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			lastScaleOut = *scaleOutOutput.StartTime
 		}
 		scalingTimeDiff := time.Now().Sub(scalingLastActivityStartTime)
-		log.Printf("Succesfully retrieved last scaling activity events from asg which took %s", scalingTimeDiff)
+		log.Printf("Succesfully retrieved last scaling activity events. Last scale out %v, last scale in %v. Discovery took %s.", lastScaleOut, lastScaleIn, scalingTimeDiff)
     case <- asgActivityTimeout:
         log.Printf("Failed to retrieve last scaling activity events due to %s timeout", asgActivityTimeoutDuration)
 	}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -147,7 +147,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			}
 			scaleOutOutput, scaleInOutput, err := asg.GetLastScalingInAndOutActivity()
 			if err != nil {
-				log.Printf("Failed to get scaling in last activity because %s ", err)
+				log.Printf("Failed to get last scale in and out activity because %s", err)
 			}
 			if scaleInOutput != nil {
 				lastScaleIn = *scaleInOutput.StartTime

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -158,22 +158,23 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 
 	select {
     case res := <-c1:
-		if err != nil {
-			log.Printf("Failed to get last scale in and out activity because %s", err)
-		} else {
-			scaleInOutput := res.LastScaleInActivity
-			if scaleInOutput != nil {
-				lastScaleIn = *scaleInOutput.StartTime
-			}
-			scaleOutOutput := res.LastScaleOutActivity
-			if scaleOutOutput != nil {
-				lastScaleOut = *scaleOutOutput.StartTime
-			}
-			scalingTimeDiff := time.Now().Sub(scalingLastActivityStartTime)
-			log.Printf("Succesfully retrieved last scaling activity events from asg which took %s", scalingTimeDiff)		
+		if res.Err != nil {
+			log.Printf("Failed to get last scale in and out activity because %s", res.Err)
+			break;
 		}
+
+		scaleInOutput := res.LastScaleInActivity
+		if scaleInOutput != nil {
+			lastScaleIn = *scaleInOutput.StartTime
+		}
+		scaleOutOutput := res.LastScaleOutActivity
+		if scaleOutOutput != nil {
+			lastScaleOut = *scaleOutOutput.StartTime
+		}
+		scalingTimeDiff := time.Now().Sub(scalingLastActivityStartTime)
+		log.Printf("Succesfully retrieved last scaling activity events from asg which took %s", scalingTimeDiff)
     case <- asgActivityTimeout:
-        log.Printf("Failed to get scale in and out last activity due to %s timeout", asgActivityTimeoutDuration)
+        log.Printf("Failed to retrieve last scaling activity events due to %s timeout", asgActivityTimeoutDuration)
 	}
 
 	for {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -140,7 +140,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				Sess: sess,
 			}
 			var lastScaleIn time.Time
-			output, err := asg.GetLastTerminatingActivity()
+			output, err := asg.GetLastScalingInActivity()
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -148,7 +148,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				lastScaleIn = *output.StartTime
 			}
 			var lastScaleOut time.Time
-			output, err = asg.GetLastLaunchingActivity()
+			output, err = asg.GetLastScalingOutActivity()
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -159,7 +159,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	select {
     case res := <-c1:
 		if res.Err != nil {
-			log.Printf("Failed to get last scale in and out activity because %s", res.Err)
+			log.Printf("Failed to retrieve last scaling activity events due to error (%s)", res.Err)
 			break;
 		}
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -169,7 +169,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			if scaleOutOutput != nil {
 				lastScaleOut = *scaleOutOutput.StartTime
 			}
-			scalingTimeDiff := scalingLastActivityStartTime.Sub(time.Now())
+			scalingTimeDiff := time.Now().Sub(scalingLastActivityStartTime)
 			log.Printf("Succesfully retrieved last scaling activity events from asg which took %s", scalingTimeDiff)		
 		}
     case <- asgActivityTimeout:
@@ -198,6 +198,8 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 				)
 			}
 
+			log.Printf("Last scale in event: %s", lastScaleIn)
+			log.Printf("Last scale out event: %s", lastScaleOut)
 			client := buildkite.NewClient(token)
 			params := scaler.Params{
 				BuildkiteQueue:       mustGetEnv(`BUILDKITE_QUEUE`),

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -203,6 +203,10 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 					interval)
 			}
 
+			// Persist the times back into the global state
+			lastScaleIn = scaler.LastScaleIn()
+			lastScaleOut = scaler.LastScaleOut()
+
 			log.Printf("Waiting for %v", interval)
 			time.Sleep(interval)
 		}

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -110,9 +110,9 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity() (*autoscaling.Activity, *au
 			// Filter for successful activity and explicit desired count changes
 			if *activity.StatusCode == activitySucessfulStatusCode &&
 				strings.Contains(*activity.Cause, userRequestForChangingDesiredCapacity) {
-				if strings.Contains(*activity.Cause, scalingOutKey) {
+				if lastScalingOutActivity == nil && strings.Contains(*activity.Cause, scalingOutKey) {
 					lastScalingOutActivity = activity
-				} else if strings.Contains(*activity.Cause, shrinkingKey) {
+				} else if lastScalingInActivity == nil && strings.Contains(*activity.Cause, shrinkingKey) {
 					lastScalingInActivity = activity
 				}
 			}

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -120,6 +120,9 @@ func (a *ASGDriver) GetLastLaunchingActivity() (*autoscaling.Activity, error) {
 				return activity, nil
 			}
 		}
+		if output.NextToken == nil {
+			break
+		}
 		nextToken = output.NextToken
 	}
 	return nil, nil

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -118,6 +118,7 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity() (*autoscaling.Activity, *au
 			}
 			if lastScalingOutActivity != nil && lastScalingInActivity != nil {
 				hasFoundScalingActivities = true
+				break
 			}
 		}
 		nextToken = output.NextToken

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -10,6 +10,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
+const (
+	activitySucessfulStatusCode = "Successful"
+)
+
 type AutoscaleGroupDetails struct {
 	Pending      int64
 	DesiredCount int64
@@ -98,11 +102,14 @@ func (a *ASGDriver) GetLastTerminatingActivity() (*autoscaling.Activity, error) 
 			return nil, err
 		}
 		for _, activity := range output.Activities {
-			if strings.Contains(*activity.Description, terminatingKey) {
+			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Description, terminatingKey) {
 				return activity, nil
 			}
 		}
 		nextToken = output.NextToken
+		if nextToken == nil {
+			break
+		}
 	}
 	return nil, nil
 }
@@ -116,14 +123,14 @@ func (a *ASGDriver) GetLastLaunchingActivity() (*autoscaling.Activity, error) {
 			return nil, err
 		}
 		for _, activity := range output.Activities {
-			if strings.Contains(*activity.Description, launchingKey) {
+			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Description, launchingKey) {
 				return activity, nil
 			}
 		}
-		if output.NextToken == nil {
+		nextToken = output.NextToken
+		if nextToken == nil {
 			break
 		}
-		nextToken = output.NextToken
 	}
 	return nil, nil
 }

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -93,8 +93,8 @@ func (a *ASGDriver) GetAutoscalingActivities(nextToken *string) (*autoscaling.De
 	return svc.DescribeScalingActivities(input)
 }
 
-func (a *ASGDriver) GetLastTerminatingActivity() (*autoscaling.Activity, error) {
-	const terminatingKey = "Terminating"
+func (a *ASGDriver) GetLastScalingInActivity() (*autoscaling.Activity, error) {
+	const shrinkingKey = "shrinking the capacity"
 	var nextToken *string
 	for {
 		output, err := a.GetAutoscalingActivities(nextToken)
@@ -102,7 +102,7 @@ func (a *ASGDriver) GetLastTerminatingActivity() (*autoscaling.Activity, error) 
 			return nil, err
 		}
 		for _, activity := range output.Activities {
-			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Description, terminatingKey) {
+			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Cause, shrinkingKey) {
 				return activity, nil
 			}
 		}
@@ -114,8 +114,8 @@ func (a *ASGDriver) GetLastTerminatingActivity() (*autoscaling.Activity, error) 
 	return nil, nil
 }
 
-func (a *ASGDriver) GetLastLaunchingActivity() (*autoscaling.Activity, error) {
-	const launchingKey = "Launching"
+func (a *ASGDriver) GetLastScalingOutActivity() (*autoscaling.Activity, error) {
+	const scalingOutKey = "increasing the capacity"
 	var nextToken *string
 	for {
 		output, err := a.GetAutoscalingActivities(nextToken)
@@ -123,7 +123,7 @@ func (a *ASGDriver) GetLastLaunchingActivity() (*autoscaling.Activity, error) {
 			return nil, err
 		}
 		for _, activity := range output.Activities {
-			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Description, launchingKey) {
+			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Cause, scalingOutKey) {
 				return activity, nil
 			}
 		}

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	activitySucessfulStatusCode = "Successful"
+	userRequestForChangingDesiredCapacity = "a user request explicitly set group desired capacity changing the desired capacity"
 )
 
 type AutoscaleGroupDetails struct {
@@ -102,7 +103,10 @@ func (a *ASGDriver) GetLastScalingInActivity() (*autoscaling.Activity, error) {
 			return nil, err
 		}
 		for _, activity := range output.Activities {
-			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Cause, shrinkingKey) {
+			// Filter for successful activity and explicit desired count changes
+			if *activity.StatusCode == activitySucessfulStatusCode &&
+				strings.Contains(*activity.Cause, userRequestForChangingDesiredCapacity) &&
+				strings.Contains(*activity.Cause, shrinkingKey) {
 				return activity, nil
 			}
 		}
@@ -123,7 +127,10 @@ func (a *ASGDriver) GetLastScalingOutActivity() (*autoscaling.Activity, error) {
 			return nil, err
 		}
 		for _, activity := range output.Activities {
-			if *activity.StatusCode == activitySucessfulStatusCode && strings.Contains(*activity.Cause, scalingOutKey) {
+			// Filter for successful activity and explicit desired count changes
+			if *activity.StatusCode == activitySucessfulStatusCode &&
+				strings.Contains(*activity.Cause, userRequestForChangingDesiredCapacity) &&
+				strings.Contains(*activity.Cause, scalingOutKey) {
 				return activity, nil
 			}
 		}

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -101,7 +101,7 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity() (*autoscaling.Activity, *au
 	var lastScalingOutActivity *autoscaling.Activity
 	var lastScalingInActivity *autoscaling.Activity
 	hasFoundScalingActivities := false
-	for hasFoundScalingActivities {
+	for !hasFoundScalingActivities {
 		output, err := a.GetAutoscalingActivities(nextToken)
 		if err != nil {
 			return nil, nil, err

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -67,9 +67,9 @@ func NewScaler(client *buildkite.Client, sess *session.Session, params Params) (
 			scaler.metrics = &dryRunMetricsPublisher{}
 		}
 	} else {
-		scaler.autoscaling = &asgDriver{
-			name: params.AutoScalingGroupName,
-			sess: sess,
+		scaler.autoscaling = &ASGDriver{
+			Name: params.AutoScalingGroupName,
+			Sess: sess,
 		}
 
 		if params.PublishCloudWatchMetrics {
@@ -177,7 +177,6 @@ func (s *Scaler) scaleIn(desired int64, current AutoscaleGroupDetails) error {
 		return err
 	}
 
-	s.scaleInParams.LastEvent = time.Now()
 	return nil
 }
 
@@ -229,7 +228,6 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 		return err
 	}
 
-	s.scaleOutParams.LastEvent = time.Now()
 	return nil
 }
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -177,6 +177,7 @@ func (s *Scaler) scaleIn(desired int64, current AutoscaleGroupDetails) error {
 		return err
 	}
 
+	s.scaleInParams.LastEvent = time.Now()
 	return nil
 }
 
@@ -228,6 +229,7 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 		return err
 	}
 
+	s.scaleOutParams.LastEvent = time.Now()
 	return nil
 }
 


### PR DESCRIPTION
Currently, the scale in and out event time is set and stored as a global variable. However, if the service does not run in the same container, the event is always reset to 0 and will scale in and out immediately. This change will set the last scale in and out event based on the autoscaler's activity event, so if the service does not run on the same lambda container, it will keep the state of the last time it scaled in or out.