### PR TITLE
Remove SSM type from BuildkiteAgentTokenParameter

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -19,7 +19,7 @@ Parameters:
     MinLength: 1
 
   AgentAutoScaleGroup:
-    Description: The name of the autoscale group to autoscale.
+    Description: The name of the Auto Scaling group to set desired count on.
     Type: String
     Default: default
 


### PR DESCRIPTION
CloudFormation, likely as part of the parameter validation, attempts to `GetParameter` this parameter even though we don’t use the value. For SSM Parameters using Secrets Manager reference syntax this fails without the inclusion of the `WithDecryption` flag. Removing the type from this parameter and replacing it with the generic `String` should fix this issue.