### PR TITLE
Fix null dereference in cloudwatch publisher

### DIFF
--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -76,7 +76,9 @@ func NewScaler(client *buildkite.Client, sess *session.Session, params Params) (
 		}
 
 		if params.PublishCloudWatchMetrics {
-			scaler.metrics = &cloudWatchMetricsPublisher{}
+			scaler.metrics = &cloudWatchMetricsPublisher{
+				sess: sess,
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes a bug introduced in #48, where the CloudWatch Metrics Publisher session field was defaulting to nil and crashing.
