### PR TITLE
Parameterise DisableScaleIn in the template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -52,6 +52,14 @@ Parameters:
       - "false"
     Default: "false"
 
+  DisableScaleIn:
+    Description: Whether the desired count should ever be decreased on the given Auto Scaling group. Defaults to true, instances are expected to self terminate when they are idle.
+    Type: String
+    AllowedValues:
+      - "true"
+      - "false"
+    Default: "true"
+
 Conditions:
   CreateRole:
     !Equals [ !Ref AutoscalingLambdaExecutionRole, '' ]
@@ -150,7 +158,7 @@ Resources:
           BUILDKITE_QUEUE:               !Ref BuildkiteQueue
           AGENTS_PER_INSTANCE:           !Ref AgentsPerInstance
           CLOUDWATCH_METRICS:            "1"
-          DISABLE_SCALE_IN:              "1"
+          DISABLE_SCALE_IN:              !Ref DisableScaleIn
           ASG_NAME:                      !Ref AgentAutoScaleGroup
           MIN_SIZE:                      !Ref MinSize
           MAX_SIZE:                      !Ref MaxSize


### PR DESCRIPTION
Adds a new optional `DisableScaleIn` parameter that defaults to `true`, the current value. This allows importing stacks to set this to `false` and enable the scale in behaviour of the scaling lambda.