### PR TITLE
Update IAM policy to allow describing scaling activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ An AWS Lambda bundle is created and published as part of the build process. The 
 
 - `cloudwatch:PutMetricData`
 - `autoscaling:DescribeAutoScalingGroups`
+- `autoscaling:DescribeScalingActivities`
 - `autoscaling:SetDesiredCapacity`
 
 It's entrypoint is `handler`, it requires a `go1.x` environment and requires the following env vars:

--- a/template.yaml
+++ b/template.yaml
@@ -116,6 +116,7 @@ Resources:
                   - autoscaling:DescribeAutoScalingGroups
                   # *
                   - autoscaling:SetDesiredCapacity
+                  - autoscaling:DescribeScalingActivities
                   # # arn:aws:autoscaling:$region:$account:autoScalingGroup:$uuid:autoScalingGroupName/$name
                 Resource: '*'
         - PolicyName: WriteCloudwatchMetrics


### PR DESCRIPTION
The changes in #52 introduced a new call to the AutoScaling API and this updates the IAM policy in the CloudFormation template accordingly.

Fixes #68 