### PR TITLE
Bump version + changelog for v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.3.1](https://github.com/buildkite/buildkite-agent-scaler/tree/v1.3.1) (2022-06-09)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.3.0...v1.3.1)
+
+### Changed
+- Fix CI snafu that caused 1.3.0 to never be properly released [#64](https://github.com/buildkite/buildkite-agent-scaler/pull/64) (@moskyb)
+
 ## [1.3.0](https://github.com/buildkite/buildkite-agent-scaler/tree/1.3.0) (2022-06-07)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.2.0...1.3.0)
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.3.0"
+const Version = "1.3.1"
 
 // The build number
 var Build string


### PR DESCRIPTION
The CI issue that prevented us from releasing 1.3.0 has now been fixed, so this release should actually get released.