### PR TITLE
Add ability to account for permanent agents

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,8 @@ func main() {
 		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
 
 		// general params
-		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
+		dryRun          = flag.Bool("dry-run", false, "Whether to just show what would be done")
+		permanentAgents = flag.Int64("permanent-agents", 0, "Number of agents always on")
 	)
 	flag.Parse()
 
@@ -56,6 +57,7 @@ func main() {
 		IncludeWaiting:           *includeWaiting,
 		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
 		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
+		PermanentAgents:          *permanentAgents,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -28,6 +28,7 @@ type Params struct {
 	ScaleInParams            ScaleParams
 	ScaleOutParams           ScaleParams
 	ScaleOnlyAfterAllEvent   bool
+	PermanentAgents          int64
 }
 
 type Scaler struct {
@@ -41,9 +42,9 @@ type Scaler struct {
 	metrics interface {
 		Publish(orgSlug, queue string, metrics map[string]int64) error
 	}
-	scaling        ScalingCalculator
-	scaleInParams  ScaleParams
-	scaleOutParams ScaleParams
+	scaling                ScalingCalculator
+	scaleInParams          ScaleParams
+	scaleOutParams         ScaleParams
 	scaleOnlyAfterAllEvent bool
 }
 
@@ -53,14 +54,15 @@ func NewScaler(client *buildkite.Client, sess *session.Session, params Params) (
 			client: client,
 			queue:  params.BuildkiteQueue,
 		},
-		scaleInParams:  params.ScaleInParams,
-		scaleOutParams: params.ScaleOutParams,
+		scaleInParams:          params.ScaleInParams,
+		scaleOutParams:         params.ScaleOutParams,
 		scaleOnlyAfterAllEvent: params.ScaleOnlyAfterAllEvent,
 	}
 
 	scaler.scaling = ScalingCalculator{
 		includeWaiting:    params.IncludeWaiting,
 		agentsPerInstance: params.AgentsPerInstance,
+		permanentAgents:   params.PermanentAgents,
 	}
 
 	if params.DryRun {

--- a/scaler/scaling_calculator.go
+++ b/scaler/scaling_calculator.go
@@ -10,6 +10,7 @@ import (
 type ScalingCalculator struct {
 	includeWaiting    bool
 	agentsPerInstance int
+	permanentAgents   int64
 }
 
 func (sc *ScalingCalculator) perInstance(count int64) int64 {
@@ -29,6 +30,12 @@ func (sc *ScalingCalculator) DesiredCount(metrics *buildkite.AgentMetrics, asg *
 		agentsRequired += metrics.WaitingJobs
 	} else {
 		agentsRequired += metrics.RunningJobs
+	}
+
+	if agentsRequired-sc.permanentAgents < 0 {
+		agentsRequired = 0
+	} else {
+		agentsRequired -= sc.permanentAgents
 	}
 
 	var desired int64


### PR DESCRIPTION
We have some permanent buildkite agents that are always on in our environment, so I created a parameter that could account for the always on agents. Before, even if a job was picked up by our permanent agents, the autoscaler would still add an agent, so we wanted to stop that from happening.

I'm hoping other users might find this feature helpful as well.