### PR TITLE
Bump version + changelog for v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+## [1.3.2](https://github.com/buildkite/buildkite-agent-scaler/tree/1.3.2) (2022-08-04)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.3.1...1.3.2)
+
+### Fixed
+- Update IAM policy to allow describing scaling activities [#61](https://github.com/buildkite/buildkite-agent-scaler/pull/61) (@zl4bv)
 
 ## [v1.3.1](https://github.com/buildkite/buildkite-agent-scaler/tree/v1.3.1) (2022-06-09)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.3.0...v1.3.1)

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.3.1"
+const Version = "1.3.2"
 
 // The build number
 var Build string


### PR DESCRIPTION
This PR will release v1.3.2, which fixes an issue with describing scaling activities on ASGs.