### PR TITLE
Allow running scaler with a fixed size instance buffer

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -58,6 +58,8 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		scaleOutCooldownPeriod time.Duration
 		scaleOutFactor         float64
 
+		instanceBuffer = 0
+
 		scaleOnlyAfterAllEvent bool
 
 		includeWaiting bool
@@ -122,6 +124,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	if v := os.Getenv(`INCLUDE_WAITING`); v != "" {
 		if v == "true" || v == "1" {
 			includeWaiting = true
+		}
+	}
+
+	if v := os.Getenv(`INSTANCE_BUFFER`); v != "" {
+		if instanceBuffer, err = strconv.Atoi(v); err != nil {
+			return "", err
 		}
 	}
 
@@ -223,6 +231,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 					Factor:         scaleOutFactor,
 					LastEvent:      lastScaleOut,
 				},
+				InstanceBuffer: instanceBuffer,
 				ScaleOnlyAfterAllEvent: scaleOnlyAfterAllEvent,
 			}
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 		// scale in/out params
 		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
 		scaleOutFactor = flag.Float64("scale-out-factor", 1.0, "A factor to apply to scale outs")
+		instanceBuffer = flag.Int("instance-buffer", 0, "Keep this many instances as extra capacity")
 
 		// general params
 		dryRun = flag.Bool("dry-run", false, "Whether to just show what would be done")
@@ -56,6 +57,7 @@ func main() {
 		IncludeWaiting:           *includeWaiting,
 		ScaleInParams:            scaler.ScaleParams{Factor: *scaleInFactor},
 		ScaleOutParams:           scaler.ScaleParams{Factor: *scaleOutFactor},
+		InstanceBuffer:           *instanceBuffer,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -27,6 +27,7 @@ type Params struct {
 	IncludeWaiting           bool
 	ScaleInParams            ScaleParams
 	ScaleOutParams           ScaleParams
+	InstanceBuffer           int
 	ScaleOnlyAfterAllEvent   bool
 }
 
@@ -44,6 +45,7 @@ type Scaler struct {
 	scaling        ScalingCalculator
 	scaleInParams  ScaleParams
 	scaleOutParams ScaleParams
+	instanceBuffer int
 	scaleOnlyAfterAllEvent bool
 }
 
@@ -55,6 +57,7 @@ func NewScaler(client *buildkite.Client, sess *session.Session, params Params) (
 		},
 		scaleInParams:  params.ScaleInParams,
 		scaleOutParams: params.ScaleOutParams,
+		instanceBuffer: params.InstanceBuffer,
 		scaleOnlyAfterAllEvent: params.ScaleOnlyAfterAllEvent,
 	}
 
@@ -107,7 +110,7 @@ func (s *Scaler) Run() (time.Duration, error) {
 		return metrics.PollDuration, err
 	}
 
-	desired := s.scaling.DesiredCount(&metrics, &asg)
+	desired := s.scaling.DesiredCount(&metrics, &asg) + int64(s.instanceBuffer)
 
 	if desired > asg.MaxSize {
 		log.Printf("⚠️  Desired count exceed MaxSize, capping at %d", asg.MaxSize)

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -44,6 +44,21 @@ func TestScalingOutWithoutError(t *testing.T) {
 			currentDesiredCapacity:  2,
 			expectedDesiredCapacity: 28,
 		},
+		// Basic scale out with instance buffer
+		{
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   2,
+				WaitingJobs:   2,
+				TotalAgents:   2,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				InstanceBuffer:    10,
+			},
+			currentDesiredCapacity:  12,
+			expectedDesiredCapacity: 22,
+		},
 		// Scale-out with multiple agents per instance
 		{
 			metrics: buildkite.AgentMetrics{
@@ -245,6 +260,7 @@ func TestScalingOutWithoutError(t *testing.T) {
 				bk:             &buildkiteTestDriver{metrics: tc.metrics},
 				scaleOutParams: tc.params.ScaleOutParams,
 				scaleInParams: tc.params.ScaleInParams,
+				instanceBuffer: tc.params.InstanceBuffer,
 				scaleOnlyAfterAllEvent: tc.params.ScaleOnlyAfterAllEvent,
 				scaling: ScalingCalculator{
 					includeWaiting:    tc.params.IncludeWaiting,
@@ -303,6 +319,21 @@ func TestScalingInWithoutError(t *testing.T) {
 			},
 			currentDesiredCapacity:  10,
 			expectedDesiredCapacity: 9,
+		},
+		// Calculate using an instance buffer
+		{
+			metrics: buildkite.AgentMetrics{
+				ScheduledJobs: 10,
+				RunningJobs:   5,
+				IdleAgents:    25,
+				TotalAgents:   30,
+			},
+			params: Params{
+				AgentsPerInstance: 1,
+				InstanceBuffer: 10,
+			},
+			currentDesiredCapacity:  30,
+			expectedDesiredCapacity: 25,
 		},
 		// With 500% factor, we scale all the way down despite scheduled jobs
 		{
@@ -385,6 +416,7 @@ func TestScalingInWithoutError(t *testing.T) {
 				},
 				scaleInParams: tc.params.ScaleInParams,
 				scaleOutParams: tc.params.ScaleOutParams,
+				instanceBuffer: tc.params.InstanceBuffer,
 				scaleOnlyAfterAllEvent: tc.params.ScaleOnlyAfterAllEvent,
 			}
 

--- a/template.yaml
+++ b/template.yaml
@@ -44,6 +44,10 @@ Parameters:
     Description: ""
     Type: Number
 
+  InstanceBuffer:
+    Description: How many free instances to maintain
+    Type: Number
+
   ScaleOutForWaitingJobs:
     Description: ""
     Type: String
@@ -173,6 +177,7 @@ Resources:
           MIN_SIZE:                      !Ref MinSize
           MAX_SIZE:                      !Ref MaxSize
           SCALE_OUT_FACTOR:              !Ref ScaleOutFactor
+          INSTANCE_BUFFER:               !Ref InstanceBuffer
           INCLUDE_WAITING:               !Ref ScaleOutForWaitingJobs
           LAMBDA_TIMEOUT:                "50s"
           LAMBDA_INTERVAL:               "10s"


### PR DESCRIPTION
This will help fleets where instance startup time is slow, by allowing them to configure enough free instances to handle a certain amount of load while new instances spin up.