### PR TITLE
Set the version of the serverless application registry to the commit when not building a tag

### DIFF
--- a/.buildkite/pipeline-sar.yml
+++ b/.buildkite/pipeline-sar.yml
@@ -4,7 +4,7 @@ steps:
     command: ".buildkite/steps/tests.sh"
     plugins:
       - docker#v3.1.0:
-          image: "golang:1.15"
+          image: "golang:1.19"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
   - name: ":hammer: :lambda:"

--- a/.buildkite/pipeline-sar.yml
+++ b/.buildkite/pipeline-sar.yml
@@ -30,9 +30,7 @@ steps:
       - package
 
   - label: ":package: :arrow_right: :aws:"
-    key: sar
-    command:
-      - buildkite-agent artifact download 'packaged.yml' .
-      - aws serverlessrepo create-application-version --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler --template-body file://packaged.yml --semantic-version "$(buildkite-agent meta-data get version)" --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
+    key: publish
+    command: .buildkite/steps/publish-package.sh
     depends_on:
       - release

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,5 +22,3 @@ steps:
   - name: ":pipeline:"
     command: .buildkite/steps/upload-release-steps.sh
     branches: master
-
-

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: ".buildkite/steps/tests.sh"
     plugins:
       - docker#v3.1.0:
-          image: "golang:1.15"
+          image: "golang:1.19"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
   - wait

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -4,7 +4,7 @@ set -eu
 make handler.zip
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  VERSION="0.0.$BUILDKITE_BUILD_NUMBER"
+  VERSION="$(awk -F\" '/const Version/ {print $2}' version/version.go)-edge"
 else
   VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
 fi

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -4,7 +4,7 @@ set -eu
 make handler.zip
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  VERSION="$BUILDKITE_COMMIT"
+  VERSION="0.0.$BUILDKITE_BUILD_NUMBER"
 else
   VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
 fi

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -3,6 +3,11 @@ set -eu
 
 make handler.zip
 
-# set a version for later steps
-buildkite-agent meta-data set version \
-  "$(awk -F\" '/const Version/ {print $2}' version/version.go)"
+if [[ -z "${BUILDKITE_TAG:-}" ]]; then
+  VERSION="$BUILDKITE_COMMIT"
+else
+  VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
+fi
+
+# set version for later steps
+buildkite-agent meta-data set version "$VERSION"

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+VERSION=$(buildkite-agent meta-data get version)
+
+buildkite-agent artifact download 'packaged.yml' .
+
+if [[ -z "${BUILDKITE_TAG:-}" ]]; then
+  aws s3 cp \
+    --acl public-read \
+    packaged.yml \
+    "s3://buildkite-serverless-apps-us-east-1/packaged/elastic-ci/agent-scaler/$VERSION/packaged.yml"
+
+else
+  aws serverlessrepo create-application-version \
+    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
+    --template-body file://packaged.yml \
+    --semantic-version "$VERSION" \
+    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
+fi

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -7,11 +7,11 @@ VERSION=$(buildkite-agent meta-data get version)
 buildkite-agent artifact download 'packaged.yml' .
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  aws s3 cp \
-    --acl public-read \
-    packaged.yml \
-    "s3://buildkite-serverless-apps-us-east-1/packaged/elastic-ci/agent-scaler/$VERSION/packaged.yml"
-
+  aws serverlessrepo create-application-version \
+    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler-edge \
+    --template-body file://packaged.yml \
+    --semantic-version "$VERSION" \
+    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
 else
   aws serverlessrepo create-application-version \
     --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -6,16 +6,8 @@ VERSION=$(buildkite-agent meta-data get version)
 
 buildkite-agent artifact download 'packaged.yml' .
 
-if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  aws serverlessrepo create-application-version \
-    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler-edge \
-    --template-body file://packaged.yml \
-    --semantic-version "$VERSION" \
-    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
-else
-  aws serverlessrepo create-application-version \
-    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
-    --template-body file://packaged.yml \
-    --semantic-version "$VERSION" \
-    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
-fi
+aws serverlessrepo create-application-version \
+  --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
+  --template-body file://packaged.yml \
+  --semantic-version "$VERSION" \
+  --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lambda/handler: lambda/main.go
 		--volume go-module-cache:/go/pkg/mod \
 		--volume $(PWD):/go/src/github.com/buildkite/buildkite-agent-scaler \
 		--workdir /go/src/github.com/buildkite/buildkite-agent-scaler \
-		--rm golang:1.15 \
+		--rm golang:1.19 \
 		go build -ldflags="$(LD_FLAGS)" -o ./lambda/handler ./lambda
 	chmod +x lambda/handler
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,14 @@ LAMBDA_S3_BUCKET_PATH := /
 
 ifdef BUILDKITE_BUILD_NUMBER
 	LD_FLAGS := -s -w -X version.Build=$(BUILDKITE_BUILD_NUMBER)
+	BUILDVSC_FLAG := false
+	USER := 0:0
 endif
 
 ifndef BUILDKITE_BUILD_NUMBER
 	LD_FLAGS := -s -w
+	BUILDVSC_FLAG := true
+	USER := "$(shell id -u):$(shell id -g)"
 endif
 
 build: handler.zip
@@ -26,12 +30,12 @@ handler.zip: lambda/handler
 
 lambda/handler: lambda/main.go
 	docker run \
-		--volume go-module-cache:/go/pkg/mod \
-		--volume $(PWD):/go/src/github.com/buildkite/buildkite-agent-scaler \
-		--workdir /go/src/github.com/buildkite/buildkite-agent-scaler \
+		--env GOCACHE=/go/cache \
+		--user $(USER) \
+		--volume $(PWD):/app \
+		--workdir /app \
 		--rm golang:1.19 \
-		go build -ldflags="$(LD_FLAGS)" -o ./lambda/handler ./lambda
-	chmod +x lambda/handler
+		go build -ldflags="$(LD_FLAGS)" -buildvcs="$(BUILDVSC_FLAG)" -o ./lambda/handler
 
 lambda-sync: handler.zip
 	aws s3 sync \


### PR DESCRIPTION
This will enable testing a version of buildkite-agent scaler before releasing it.