### PR TITLE
Add parameter to configure logs retention

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -65,6 +65,11 @@ Parameters:
     Description: The ARN of the policy used to set the permissions boundary for the role.
     Default: ""
 
+  LogRetentionDays:
+    Type: Number
+    Description: The number of days to retain the Cloudwatch Logs of the lambda.
+    Default: 1
+
 Conditions:
   CreateRole:
     !Equals [ !Ref AutoscalingLambdaExecutionRole, '' ]
@@ -188,7 +193,7 @@ Resources:
     Type: "AWS::Logs::LogGroup"
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AutoscalingFunction}"
-      RetentionInDays: 1
+      RetentionInDays: !Ref LogRetentionDays
 
 Outputs:
   ExecutionRoleName:


### PR DESCRIPTION
This PR adds a Cloudformation parameter to configure the cloudwatch log retention. This is currently hardcoded to 1 day, and we'd like to set this to a higher number like 180 days.