### PR TITLE
Update go 1.15 -> 1.19

### DIFF
--- a/.buildkite/pipeline-sar.yml
+++ b/.buildkite/pipeline-sar.yml
@@ -4,7 +4,7 @@ steps:
     command: ".buildkite/steps/tests.sh"
     plugins:
       - docker#v3.1.0:
-          image: "golang:1.15"
+          image: "golang:1.19"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
   - name: ":hammer: :lambda:"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     command: ".buildkite/steps/tests.sh"
     plugins:
       - docker#v3.1.0:
-          image: "golang:1.15"
+          image: "golang:1.19"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
   - wait
@@ -22,5 +22,3 @@ steps:
   - name: ":pipeline:"
     command: .buildkite/steps/upload-release-steps.sh
     branches: master
-
-

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ lambda/handler: lambda/main.go
 		--volume go-module-cache:/go/pkg/mod \
 		--volume $(PWD):/go/src/github.com/buildkite/buildkite-agent-scaler \
 		--workdir /go/src/github.com/buildkite/buildkite-agent-scaler \
-		--rm golang:1.15 \
+		--rm golang:1.19 \
 		go build -ldflags="$(LD_FLAGS)" -o ./lambda/handler ./lambda
 	chmod +x lambda/handler
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,15 @@
 module github.com/buildkite/buildkite-agent-scaler
 
-go 1.15
+go 1.19
 
 require (
 	github.com/aws/aws-lambda-go v1.7.0
 	github.com/aws/aws-sdk-go v1.19.24
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2 // indirect
 	golang.org/x/net v0.0.0-20181114220301-adae6a3d119a // indirect


### PR DESCRIPTION
**This PR:** Updates the scaler from Go 1.15 to Go 1.19, the latest stable. This may fix some test errors on recent branches