### PR TITLE
Limit pagination of autoscaling:DescribeScalingActivity

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -133,6 +133,11 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		}
 	}
 
+	maxPages := 0
+	if v := os.Getenv("MAX_PAGES"); v != "" {
+		maxPages, _ = strconv.Atoi(v)
+	}
+
 	var mustGetEnv = func(env string) string {
 		val := os.Getenv(env)
 		if val == "" {
@@ -155,8 +160,9 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 
 	// set last scale in and out from asg's activities
 	asg := &scaler.ASGDriver{
-		Name: mustGetEnv(`ASG_NAME`),
-		Sess: sess,
+		Name:     mustGetEnv(`ASG_NAME`),
+		Sess:     sess,
+		MaxPages: maxPages,
 	}
 
 	c1 := make(chan LastScaleASGResult, 1)

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -133,9 +133,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		}
 	}
 
-	maxPages := 0
-	if v := os.Getenv("MAX_PAGES"); v != "" {
-		maxPages, _ = strconv.Atoi(v)
+	maxDescribeScalingActivitiesPages := -1
+	if v := os.Getenv("MAX_DESCRIBE_SCALING_ACTIVITIES_PAGES"); v != "" {
+		maxDescribeScalingActivitiesPages, err = strconv.Atoi(v)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to parse MAX_DESCRIBE_SCALING_ACTIVITIES_PAGES: %v", err)
+		}
 	}
 
 	var mustGetEnv = func(env string) string {
@@ -160,9 +163,9 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 
 	// set last scale in and out from asg's activities
 	asg := &scaler.ASGDriver{
-		Name:     mustGetEnv(`ASG_NAME`),
-		Sess:     sess,
-		MaxPages: maxPages,
+		Name:                              mustGetEnv(`ASG_NAME`),
+		Sess:                              sess,
+		MaxDescribeScalingActivitiesPages: maxDescribeScalingActivitiesPages,
 	}
 
 	c1 := make(chan LastScaleASGResult, 1)

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -107,12 +107,12 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context) (*autosc
 	for i := 0; !hasFoundScalingActivities; {
 		i++
 		if a.MaxDescribeScalingActivitiesPages >= 0 && i >= a.MaxDescribeScalingActivitiesPages {
-			return nil, nil, fmt.Errorf("%d exceedes allowed pages for autoscaling:DescribeScalingActivities, %d", i, a.MaxDescribeScalingActivitiesPages)
+			return lastScalingOutActivity, lastScalingInActivity, fmt.Errorf("%d exceedes allowed pages for autoscaling:DescribeScalingActivities, %d", i, a.MaxDescribeScalingActivitiesPages)
 		}
 
 		output, err := a.GetAutoscalingActivities(ctx, nextToken)
 		if err != nil {
-			return nil, nil, err
+			return lastScalingOutActivity, lastScalingInActivity, err
 		}
 		for _, activity := range output.Activities {
 			// Filter for successful activity and explicit desired count changes

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -24,9 +24,9 @@ type AutoscaleGroupDetails struct {
 }
 
 type ASGDriver struct {
-	Name     string
-	Sess     *session.Session
-	MaxPages int
+	Name                              string
+	Sess                              *session.Session
+	MaxDescribeScalingActivitiesPages int
 }
 
 func (a *ASGDriver) Describe() (AutoscaleGroupDetails, error) {
@@ -103,9 +103,10 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity() (*autoscaling.Activity, *au
 	var lastScalingOutActivity *autoscaling.Activity
 	var lastScalingInActivity *autoscaling.Activity
 	hasFoundScalingActivities := false
-	for i := 0; !hasFoundScalingActivities; i++ {
-		if a.MaxPages > 0 && i > a.MaxPages {
-			return nil, nil, fmt.Errorf("%d exceedes allowed pages for autoscaling:DescribeScalingActivities, %d", i, a.MaxPages)
+	for i := 0; !hasFoundScalingActivities; {
+		i++
+		if a.MaxDescribeScalingActivitiesPages >= 0 && i >= a.MaxDescribeScalingActivitiesPages {
+			return nil, nil, fmt.Errorf("%d exceedes allowed pages for autoscaling:DescribeScalingActivities, %d", i, a.MaxDescribeScalingActivitiesPages)
 		}
 
 		output, err := a.GetAutoscalingActivities(nextToken)

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -1,6 +1,7 @@
 package scaler
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -87,16 +88,16 @@ func (a *ASGDriver) SetDesiredCapacity(count int64) error {
 	return nil
 }
 
-func (a *ASGDriver) GetAutoscalingActivities(nextToken *string) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+func (a *ASGDriver) GetAutoscalingActivities(ctx context.Context, nextToken *string) (*autoscaling.DescribeScalingActivitiesOutput, error) {
 	svc := autoscaling.New(a.Sess)
 	input := &autoscaling.DescribeScalingActivitiesInput{
 		AutoScalingGroupName: aws.String(a.Name),
 		NextToken:            nextToken,
 	}
-	return svc.DescribeScalingActivities(input)
+	return svc.DescribeScalingActivitiesWithContext(ctx, input)
 }
 
-func (a *ASGDriver) GetLastScalingInAndOutActivity() (*autoscaling.Activity, *autoscaling.Activity, error) {
+func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context) (*autoscaling.Activity, *autoscaling.Activity, error) {
 	const scalingOutKey = "increasing the capacity"
 	const shrinkingKey = "shrinking the capacity"
 	var nextToken *string
@@ -109,7 +110,7 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity() (*autoscaling.Activity, *au
 			return nil, nil, fmt.Errorf("%d exceedes allowed pages for autoscaling:DescribeScalingActivities, %d", i, a.MaxDescribeScalingActivitiesPages)
 		}
 
-		output, err := a.GetAutoscalingActivities(nextToken)
+		output, err := a.GetAutoscalingActivities(ctx, nextToken)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/template.yaml
+++ b/template.yaml
@@ -80,6 +80,11 @@ Parameters:
     Description: The number of days to retain the Cloudwatch Logs of the lambda.
     Default: "1"
 
+  MaxDescribeScalingActivitiesPages:
+    Type: Number
+    Description: The number of pages to retrive for DescribeScalingActivity. 0 means unlimited.
+    Default: 0
+
 Conditions:
   CreateRole:
     !Equals [ !Ref AutoscalingLambdaExecutionRole, '' ]
@@ -193,6 +198,7 @@ Resources:
           INCLUDE_WAITING:               !Ref ScaleOutForWaitingJobs
           LAMBDA_TIMEOUT:                "50s"
           LAMBDA_INTERVAL:               "10s"
+          MAX_DESCRIBE_SCALING_ACTIVITIES_PAGES: !Ref MaxDescribeScalingActivitiesPages
       Events:
         Timer:
           Type: Schedule

--- a/template.yaml
+++ b/template.yaml
@@ -82,8 +82,8 @@ Parameters:
 
   MaxDescribeScalingActivitiesPages:
     Type: Number
-    Description: The number of pages to retrive for DescribeScalingActivity. 0 means unlimited.
-    Default: 0
+    Description: The number of pages to retrive for DescribeScalingActivity. Negative numbers mean unlimited.
+    Default: "-1"
 
 Conditions:
   CreateRole:


### PR DESCRIPTION
This fixes a variety of issues with scaler, the main one being that, when scale in was disabled on the elastic ci stack (which it is by default), the search for the last scale in activity would alway go through the entire history of scaling events. As this is paginated, and stores 6 weeks of activity, many customers were experiencing rate limiting of of their autoscaling API calls. This rendered the elastic ci stack unable to scale out in some cases.

Until @YanivAssaf-at pointed this out, my main attempt at a solution was to impose an arbitrary limit on the pagination of the DescribeAutoScalingActivity API. I still think this could be useful, so I have kept it in.