### PR TITLE
Allow releasing development versions of buildkite-agent-scaler to the an "edge" serverless repo

### DIFF
--- a/.buildkite/pipeline-sar.yml
+++ b/.buildkite/pipeline-sar.yml
@@ -34,3 +34,6 @@ steps:
     command: .buildkite/steps/publish-package.sh
     depends_on:
       - release
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-agent-scaler-publish

--- a/.buildkite/pipeline-sar.yml
+++ b/.buildkite/pipeline-sar.yml
@@ -30,9 +30,7 @@ steps:
       - package
 
   - label: ":package: :arrow_right: :aws:"
-    key: sar
-    command:
-      - buildkite-agent artifact download 'packaged.yml' .
-      - aws serverlessrepo create-application-version --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler --template-body file://packaged.yml --semantic-version "$(buildkite-agent meta-data get version)" --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
+    key: publish
+    command: .buildkite/steps/publish-package.sh
     depends_on:
       - release

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -4,7 +4,7 @@ set -eu
 make handler.zip
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  VERSION="0.0.$BUILDKITE_BUILD_NUMBER"
+  VERSION="$(awk -F\" '/const Version/ {print $2}' version/version.go)-edge"
 else
   VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
 fi

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -4,7 +4,7 @@ set -eu
 make handler.zip
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  VERSION="$(awk -F\" '/const Version/ {print $2}' version/version.go)-edge"
+  VERSION=$(git describe --tags)
 else
   VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
 fi

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -4,7 +4,7 @@ set -eu
 make handler.zip
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  VERSION="$BUILDKITE_COMMIT"
+  VERSION="0.0.$BUILDKITE_BUILD_NUMBER"
 else
   VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
 fi

--- a/.buildkite/steps/build-lambda.sh
+++ b/.buildkite/steps/build-lambda.sh
@@ -3,6 +3,11 @@ set -eu
 
 make handler.zip
 
-# set a version for later steps
-buildkite-agent meta-data set version \
-  "$(awk -F\" '/const Version/ {print $2}' version/version.go)"
+if [[ -z "${BUILDKITE_TAG:-}" ]]; then
+  VERSION="$BUILDKITE_COMMIT"
+else
+  VERSION=$(awk -F\" '/const Version/ {print $2}' version/version.go)
+fi
+
+# set version for later steps
+buildkite-agent meta-data set version "$VERSION"

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -22,6 +22,6 @@ buildkite-agent artifact download "handler.zip" .
 
 echo "--- 🚀 Releasing $VERSION"
 export GITHUB_RELEASE_ACCESS_TOKEN
-github-release "v$VERSION" handler.zip \
+github-release "v${VERSION#v}" handler.zip \
   --commit "$(git rev-parse HEAD)" \
   --github-repository "buildkite/buildkite-agent-scaler"

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+
+set -eufo pipefail
 
 echo '--- Getting credentials from SSM'
 GITHUB_RELEASE_ACCESS_TOKEN=$( \

--- a/.buildkite/steps/github-release.sh
+++ b/.buildkite/steps/github-release.sh
@@ -2,7 +2,14 @@
 set -e
 
 echo '--- Getting credentials from SSM'
-export GITHUB_RELEASE_ACCESS_TOKEN=$(aws ssm get-parameter --name /pipelines/buildkite-agent-scaler/GITHUB_RELEASE_ACCESS_TOKEN --with-decryption --output text --query Parameter.Value --region us-east-1)
+GITHUB_RELEASE_ACCESS_TOKEN=$( \
+  aws ssm get-parameter \
+    --name /pipelines/buildkite-agent-scaler/GITHUB_RELEASE_ACCESS_TOKEN \
+    --with-decryption \
+    --output text \
+    --query Parameter.Value \
+    --region us-east-1 \
+)
 
 if [[ "$GITHUB_RELEASE_ACCESS_TOKEN" == "" ]]; then
   echo "Error: Missing \$GITHUB_RELEASE_ACCESS_TOKEN"
@@ -13,6 +20,7 @@ VERSION=$(buildkite-agent meta-data get "version")
 buildkite-agent artifact download "handler.zip" .
 
 echo "--- 🚀 Releasing $VERSION"
+export GITHUB_RELEASE_ACCESS_TOKEN
 github-release "v$VERSION" handler.zip \
   --commit "$(git rev-parse HEAD)" \
   --github-repository "buildkite/buildkite-agent-scaler"

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eufo pipefail
+
+VERSION=$(buildkite-agent meta-data get version)
+
+buildkite-agent artifact download 'packaged.yml' .
+
+if [[ -z "${BUILDKITE_TAG:-}" ]]; then
+  aws s3 cp \
+    --acl public-read \
+    packaged.yml \
+    "s3://buildkite-serverless-apps-us-east-1/packaged/elastic-ci/agent-scaler/$VERSION/packaged.yml"
+
+else
+  aws serverlessrepo create-application-version \
+    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
+    --template-body file://packaged.yml \
+    --semantic-version "$VERSION" \
+    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
+fi

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -7,11 +7,11 @@ VERSION=$(buildkite-agent meta-data get version)
 buildkite-agent artifact download 'packaged.yml' .
 
 if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  aws s3 cp \
-    --acl public-read \
-    packaged.yml \
-    "s3://buildkite-serverless-apps-us-east-1/packaged/elastic-ci/agent-scaler/$VERSION/packaged.yml"
-
+  aws serverlessrepo create-application-version \
+    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler-edge \
+    --template-body file://packaged.yml \
+    --semantic-version "$VERSION" \
+    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
 else
   aws serverlessrepo create-application-version \
     --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -16,5 +16,5 @@ echo --- ":aws::lambda: Publishing version $VERSION to SAR"
 aws serverlessrepo create-application-version \
   --application-id "$APP_ID" \
   --template-body file://packaged.yml \
-  --semantic-version "$VERSION" \
+  --semantic-version "${VERSION#v}" \
   --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -6,8 +6,14 @@ VERSION=$(buildkite-agent meta-data get version)
 
 buildkite-agent artifact download 'packaged.yml' .
 
+if [[ -z $BUILDKITE_TAG ]]; then
+  APP_ID=arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler-edge
+else
+  APP_ID=arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler
+fi
+
 aws serverlessrepo create-application-version \
-  --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
+  --application-id "$APP_ID" \
   --template-body file://packaged.yml \
   --semantic-version "$VERSION" \
   --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -6,16 +6,8 @@ VERSION=$(buildkite-agent meta-data get version)
 
 buildkite-agent artifact download 'packaged.yml' .
 
-if [[ -z "${BUILDKITE_TAG:-}" ]]; then
-  aws serverlessrepo create-application-version \
-    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler-edge \
-    --template-body file://packaged.yml \
-    --semantic-version "$VERSION" \
-    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
-else
-  aws serverlessrepo create-application-version \
-    --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
-    --template-body file://packaged.yml \
-    --semantic-version "$VERSION" \
-    --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"
-fi
+aws serverlessrepo create-application-version \
+  --application-id arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler \
+  --template-body file://packaged.yml \
+  --semantic-version "$VERSION" \
+  --source-code-url "https://github.com/buildkite/buildkite-agent-scaler/tree/$(git rev-parse HEAD)/"

--- a/.buildkite/steps/publish-package.sh
+++ b/.buildkite/steps/publish-package.sh
@@ -12,6 +12,7 @@ else
   APP_ID=arn:aws:serverlessrepo:us-east-1:172840064832:applications/buildkite-agent-scaler
 fi
 
+echo --- ":aws::lambda: Publishing version $VERSION to SAR"
 aws serverlessrepo create-application-version \
   --application-id "$APP_ID" \
   --template-body file://packaged.yml \

--- a/template.yaml
+++ b/template.yaml
@@ -16,12 +16,12 @@ Parameters:
     Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"
     Type: String
     Default: default
-    MinLength: 1
+    MinLength: "1"
 
   RootStackName:
     Description: Name of parent CloudFormation stack (if exists)
     Type: String
-    Default: !Ref AWS::StackName
+    Default: "Elastic CI Stack"
 
   AgentAutoScaleGroup:
     Description: The name of the Auto Scaling group to set desired count on.
@@ -68,7 +68,7 @@ Parameters:
       - "true"
       - "false"
     Default: "true"
-    
+
   RolePermissionsBoundaryARN:
     Type: String
     Description: The ARN of the policy used to set the permissions boundary for the role.
@@ -77,7 +77,7 @@ Parameters:
   LogRetentionDays:
     Type: Number
     Description: The number of days to retain the Cloudwatch Logs of the lambda.
-    Default: 1
+    Default: "1"
 
 Conditions:
   CreateRole:

--- a/template.yaml
+++ b/template.yaml
@@ -52,6 +52,7 @@ Parameters:
   InstanceBuffer:
     Description: How many free instances to maintain
     Type: Number
+    Default: "0"
 
   ScaleOutForWaitingJobs:
     Description: ""


### PR DESCRIPTION
This will allow us to deploy changes targeted to address certain customer's issues and ask them to test the change on their infrastructure.
Once we are satisfied the change works, we can merge it back in to the trunk branch.

The process for doing so is to manually start a build for the branch/commit you want to release to the edge repo. For example, for a commit that this branch once pointed to: https://buildkite.com/buildkite-aws-stack/buildkite-agent-scaler-publish/builds/49