### PR TITLE
Assume the OIDC role for release-verison too

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -8,6 +8,9 @@ steps:
       queue: elastic-runners
     concurrency: 1
     concurrency_group: 'release'
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler
 
   - wait
   - label: ":github:"


### PR DESCRIPTION
This is preventing v1.4.0 being released properly:

https://buildkite.com/buildkite/buildkite-agent-scaler/builds/254#0188c3a0-e4ed-4ac0-a804-cf360e6befcf

but I think following the pattern from #82 will fix it up.