### PR TITLE
Use the metrics route scoped to a queue to get metrics for the queue

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -96,7 +96,9 @@ func (c *Client) queryMetrics(into interface{}, queue string) (pollDuration time
 	if err != nil {
 		return time.Duration(0), err
 	}
-	endpoint.Path += fmt.Sprintf("/metrics/queue?name=%s", queue)
+	endpoint.Path += "/metrics/queue"
+	q := url.Values{"name": []string{queue}}
+	endpoint.RawQuery = q.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, endpoint.String(), nil)
 	if err != nil {


### PR DESCRIPTION
Previously, we polled the index route, which returns the metrics grouped
by queue, and then dropped the metrics for the other queues. This is
wasteful. There is a route scoped to the queue,
```
http 'agent.buildkite.localhost/v3/metrics/queue?name=default' "Authorization: Token **********"
```
it returns the JSON in the shape:
```json
{
    "agents": {
        "busy": 0,
        "idle": 0,
        "total": 0
    },
    "jobs": {
        "running": 0,
        "scheduled": 0,
        "total": 0,
        "waiting": 0
    },
    "organization": {
        "slug": "buildkite"
    }
}
```