### PR TITLE
Allow the event schedule rate to be configured via parameters

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -33,6 +33,11 @@ Parameters:
     Type: String
     Default: ''
 
+  EventScheduleRate:
+    Description: How often the Event Schedule is triggered (in minutes)
+    Type: String
+    Default: "1"
+
   AgentsPerInstance:
     Description: ""
     Type: Number
@@ -203,7 +208,7 @@ Resources:
         Timer:
           Type: Schedule
           Properties:
-            Schedule: "rate(1 minute)"
+            Schedule: !Sub "rate(${EventScheduleRate} minute)"
 
   # This mirrors the group that would be created by the lambda, but enforces
   # a retention period and also ensures it's removed when the stack is removed


### PR DESCRIPTION
## Description
This PR is being raised to allow the Event Schedule rate to be configurable via Parameter inputs. 
There is a Default value provided to ensure the change is backwards compatible. 

## Reason for the change
When there are a large number of BuildKite agent queues combined with other resources such as Cluster Autoscalers the AWS API for `DescribeAutoScalingGroupsInfo` receives a `ThrottlingException`. This has a negative impact on all services that are required to interact with the AWS Autoscaling API. 

This PR will allow for the schedule to be updated as required to ensure throttling exceptions are not triggered. 

If this PR is merged, another PR will need to be raised against the elastic CI stack to allow the parameter to be passed in. 


