### PR TITLE
Fix scaler release does not prepend a v to the version on s3

### DIFF
--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -26,7 +26,7 @@ EXTRA_REGIONS=(
   sa-east-1
 )
 
-VERSION=$(buildkite-agent meta-data get version)
+VERSION="v${BUILDKITE_TAG#v}"
 BASE_BUCKET=buildkite-lambdas
 BUCKET_PATH=buildkite-agent-scaler
 


### PR DESCRIPTION
The $BUILDKITE_TAG should have the `v`, the metadata does not. But just
in case, we remove the `v` and add it back.