### PR TITLE
Add Event Schedule Conditional

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -102,6 +102,8 @@ Conditions:
     !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ] ]
   SetRolePermissionsBoundaryARN:
     !Not [ !Equals [ !Ref RolePermissionsBoundaryARN, "" ] ]
+  EventScheduleRateIsMinute:
+    !Equals [!Ref EventScheduleRate, "1"]
 
 Mappings:
   LambdaBucket:
@@ -213,7 +215,7 @@ Resources:
         Timer:
           Type: Schedule
           Properties:
-            Schedule: !Sub "rate(${EventScheduleRate} minute)"
+            Schedule: !If [EventScheduleRateIsMinute, !Sub "rate(${EventScheduleRate} minute)", !Sub "rate(${EventScheduleRate} minutes)"]
 
   # This mirrors the group that would be created by the lambda, but enforces
   # a retention period and also ensures it's removed when the stack is removed


### PR DESCRIPTION
The when calling the AWS events api `put-rule` and using the `rate` expression, if the minute is > 1 it requires the expression to be in `minutes`. On the other side `1 minutes` will also fail and is required to be set as `1 minute`. 

The Below error was seen during a stack update:
```
{
    "eventSource": "events.amazonaws.com",
    "eventName": "PutRule",
    "sourceIPAddress": "cloudformation.amazonaws.com",
    "userAgent": "cloudformation.amazonaws.com",
    "errorCode": "ValidationException",
    "errorMessage": "Parameter ScheduleExpression is not valid.",
    "requestParameters": {
        "name": "<Obfuscated>",
        "scheduleExpression": "rate(3 minute)"
    }
}
```

The below commands have been run to confirm:
```sh
# Validation Error
aws events put-rule --name "AutoscalingFunctionTimer" --schedule-expression "rate(3 minute)"
# Validation Error
aws events put-rule --name "AutoscalingFunctionTimer" --schedule-expression "rate(1 minutes)"

# successful request
aws events put-rule --name "AutoscalingFunctionTimer" --schedule-expression "rate(2 minutes)"
# successful request
aws events put-rule --name "AutoscalingFunctionTimer" --schedule-expression "rate(1 minute)"
```