### PR TITLE
Change `EventScheduleRate` parameter to `EventSchedulePeriod` and require units

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -33,10 +33,10 @@ Parameters:
     Type: String
     Default: ''
 
-  EventScheduleRate:
-    Description: How often the Event Schedule is triggered (in minutes)
+  EventSchedulePeriod:
+    Description: How often the Event Schedule is triggered. Should be an expression with units, e.g. "30 seconds", "1 minute", "5 minutes".
     Type: String
-    Default: "1"
+    Default: "1 minute"
 
   AgentsPerInstance:
     Description: ""
@@ -89,7 +89,7 @@ Parameters:
     Type: Number
     Description: The number of pages to retrive for DescribeScalingActivity. Negative numbers mean unlimited.
     Default: "-1"
-  
+
   MinPollInterval:
     Type: String
     Description: Minimum time interval between polls. If a larger interval is provided by Buildkite, that is used instead.
@@ -213,7 +213,7 @@ Resources:
         Timer:
           Type: Schedule
           Properties:
-            Schedule: !Sub "rate(${EventScheduleRate} minute)"
+            Schedule: !Sub "rate(${EventSchedulePeriod})"
 
   # This mirrors the group that would be created by the lambda, but enforces
   # a retention period and also ensures it's removed when the stack is removed


### PR DESCRIPTION
The rate expression must pluralise the unit, so `1 minute` and `0 minutes` are valid, but `0 minute` is not.

Rather than condition on the value of the parameter, we leave this to
the user to specify whether they should use "minute" or "minutes". This
also allows them to use other units like 1 hour, 1 day, etc. Though
units that are longer or shorter than a minute are not recommended.

Since the old parameter was essentially broken (it would not succeed with any value other than the default, `1`), we've decided to rename the parameter to `EventSchedulePeriod`. This name is more accurate - a length of time like 1 minute is not a rate.