### PR TITLE
AWS Lambda end of support for the Go 1.x runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ bootstrap: lambda/main.go
 		--volume $(PWD):/app \
 		--workdir /app \
 		--rm golang:1.19 \
-		go build -ldflags="$(LD_FLAGS)" -buildvcs="$(BUILDVSC_FLAG)" -o bootstrap ./lambda
+		go build -ldflags="$(LD_FLAGS)" -buildvcs="$(BUILDVSC_FLAG)" -tags lambda.norpc -o bootstrap ./lambda
 
 lambda-sync: handler.zip
 	aws s3 sync \

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ clean:
 
 LAMBDA_S3_BUCKET := buildkite-aws-stack-lox
 LAMBDA_S3_BUCKET_PATH := /
+export CGO_ENABLED := 0
 
 ifdef BUILDKITE_BUILD_NUMBER
 	LD_FLAGS := -s -w -X version.Build=$(BUILDKITE_BUILD_NUMBER)
@@ -31,6 +32,7 @@ handler.zip: bootstrap
 bootstrap: lambda/main.go
 	docker run \
 		--env GOCACHE=/go/cache \
+		--env CGO_ENABLED \
 		--user $(USER) \
 		--volume $(PWD):/app \
 		--workdir /app \

--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,17 @@ endif
 
 build: handler.zip
 
-handler.zip: lambda/handler
+handler.zip: bootstrap
 	zip -9 -v -j $@ "$<"
 
-lambda/handler: lambda/main.go
+bootstrap: lambda/main.go
 	docker run \
 		--env GOCACHE=/go/cache \
 		--user $(USER) \
 		--volume $(PWD):/app \
 		--workdir /app \
 		--rm golang:1.19 \
-		go build -ldflags="$(LD_FLAGS)" -buildvcs="$(BUILDVSC_FLAG)" -o lambda/handler ./lambda
+		go build -ldflags="$(LD_FLAGS)" -buildvcs="$(BUILDVSC_FLAG)" -o bootstrap ./lambda
 
 lambda-sync: handler.zip
 	aws s3 sync \

--- a/template.yaml
+++ b/template.yaml
@@ -190,8 +190,10 @@ Resources:
       Role: !If [ CreateRole, !GetAtt ExecutionRole.Arn, !Ref AutoscalingLambdaExecutionRole ]
       PermissionsBoundary: !If [ SetRolePermissionsBoundaryARN, !Ref RolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       Timeout: 120
-      Handler: handler
-      Runtime: go1.x
+      Handler: bootstrap
+      Runtime: provided.al2
+      Architectures:
+        - x86_64
       MemorySize: 128
       Environment:
         Variables:


### PR DESCRIPTION
The go1.x runtime is being deprecated in favour of the provided.al2 runtime, see [this post](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/) for background.

We implemented the steps in the blog post the following PR https://github.com/buildkite/buildkite-agent-scaler/pull/103 however, at the time the library AWS-Lambda-Go was at an old version that was incompatible with the provided.al2 runtime. After the runtime was upgraded in https://github.com/buildkite/buildkite-agent-scaler/pull/107 the changes in this PR should make the scaler work with provided.al2 lambda runtime.