### PR TITLE
Update version and CHANGELOG for v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.7.0](https://github.com/buildkite/buildkite-agent-scaler/tree/v1.7.0) (2023-10-13)
+[Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.6.0...v1.7.0)
+
+### Changed
+- AWS Lambda end of support for the Go 1.x runtime [#108](https://github.com/buildkite/buildkite-agent-scaler/pull/108) (@HugeIRL)
+
+### Updated
+- Bump github.com/aws/aws-sdk-go 1.45.25 [#109](https://github.com/buildkite/buildkite-agent-scaler/pull/109) [#106](https://github.com/buildkite/buildkite-agent-scaler/pull/106) (@dependabot[bot])
+- Bump github.com/aws/aws-lambda-go from 1.7.0 to 1.41.0 [#107](https://github.com/buildkite/buildkite-agent-scaler/pull/107) (@dependabot[bot])
+
+### Internal
+- Add dependabot [#105](https://github.com/buildkite/buildkite-agent-scaler/pull/105) (@triarius)
+
 ## [v1.6.0](https://github.com/buildkite/buildkite-agent-scaler/tree/v1.6.0) (2023-09-13)
 [Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.5.1...v1.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.6.0...v1.7.0)
 
 ### Changed
-- AWS Lambda end of support for the Go 1.x runtime [#108](https://github.com/buildkite/buildkite-agent-scaler/pull/108) (@HugeIRL)
+- Updated lambda runtime to `provided.al2` in light of end of support for the Go 1.x runtime [#108](https://github.com/buildkite/buildkite-agent-scaler/pull/108) (@HugeIRL)
 
 ### Updated
 - Bump github.com/aws/aws-sdk-go 1.45.25 [#109](https://github.com/buildkite/buildkite-agent-scaler/pull/109) [#106](https://github.com/buildkite/buildkite-agent-scaler/pull/106) (@dependabot[bot])

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 // Version the library version number
-const Version = "1.6.0"
+const Version = "1.7.0"
 
 // The build number
 var Build string


### PR DESCRIPTION
## [v1.7.0](https://github.com/buildkite/buildkite-agent-scaler/tree/v1.7.0) (2023-10-13)
[Full Changelog](https://github.com/buildkite/buildkite-agent-scaler/compare/v1.6.0...v1.7.0)

### Changed
- AWS Lambda end of support for the Go 1.x runtime [#108](https://github.com/buildkite/buildkite-agent-scaler/pull/108) (@HugeIRL)

### Updated
- Bump github.com/aws/aws-sdk-go 1.45.25 [#109](https://github.com/buildkite/buildkite-agent-scaler/pull/109) [#106](https://github.com/buildkite/buildkite-agent-scaler/pull/106) (@dependabot[bot])
- Bump github.com/aws/aws-lambda-go from 1.7.0 to 1.41.0 [#107](https://github.com/buildkite/buildkite-agent-scaler/pull/107) (@dependabot[bot])

### Internal
- Add dependabot [#105](https://github.com/buildkite/buildkite-agent-scaler/pull/105) (@triarius)