### PR TITLE
Update README example due to end of support for the Go 1.x runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ aws lambda create-function \
   --function-name buildkite-agent-scaler \
   --memory 128 \
   --role arn:aws:iam::account-id:role/execution_role \
-  --runtime go1.x \
+  --runtime provided.al2 \
   --zip-file fileb://handler.zip \
   --handler handler
 ```


### PR DESCRIPTION
README example needs updated to show new runtime to be used rather than one to be made deprecated