### PR TITLE
Calm dependabot down a little

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,9 @@ updates:
 - package-ecosystem: gomod
   directory: /
   schedule:
-    interval: daily
+    interval: monthly
+  reviewers:
+    - "buildkite/@agent-stewards"
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
We added dependabot in #105 (Oct 2023) and it got very excited proposing daily updates to github.com/aws/aws-sdk-go. 

![2024-03-02_08-05](https://github.com/buildkite/buildkite-agent-scaler/assets/8132/49ed85a5-e8a7-4d1a-8c5d-3761eafebb45)

Eventually it gave up.

Maybe monthly is enough to stop dependencies falling behind, without quite so much noise?