### PR TITLE
Scaler cleanups

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,73 +2,73 @@ agents:
   queue: elastic-runners
 
 steps:
-- name: ":go: Check go fmt"
-  key: go-fmt
-  command: .buildkite/steps/test-go-fmt.sh
-  plugins:
-  - docker#v5.8.0:
-      image: golang:1.19
-      workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
+  - name: ":go: Check go fmt"
+    key: go-fmt
+    command: .buildkite/steps/test-go-fmt.sh
+    plugins:
+      - docker#v5.8.0:
+          image: golang:1.22
+          workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
-- name: ":golang: Run Tests"
-  key: test
-  command: .buildkite/steps/tests.sh
-  plugins:
-  - docker#v5.8.0:
-      image: golang:1.19
-      workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
+  - name: ":golang: Run Tests"
+    key: test
+    command: .buildkite/steps/tests.sh
+    plugins:
+      - docker#v5.8.0:
+          image: golang:1.22
+          workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
-- name: ":lambda: Build Lambda"
-  key: build-lambda
-  depends_on:
-  - go-fmt
-  command: .buildkite/steps/build-lambda.sh
-  artifact_paths:
-  - handler.zip
+  - name: ":lambda: Build Lambda"
+    key: build-lambda
+    depends_on:
+      - go-fmt
+    command: .buildkite/steps/build-lambda.sh
+    artifact_paths:
+      - handler.zip
 
-- label: ":s3: Pubish to S3 Branch Location"
-  key: s3-branch
-  depends_on:
-  - test
-  - build-lambda
-  command: .buildkite/steps/upload-to-s3.sh
-  plugins:
-  - aws-assume-role-with-web-identity:
-      role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler
+  - label: ":s3: Pubish to S3 Branch Location"
+    key: s3-branch
+    depends_on:
+      - test
+      - build-lambda
+    command: .buildkite/steps/upload-to-s3.sh
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler
 
-- if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
-  label: ":github: Draft GitHub Release"
-  key: github-release
-  depends_on:
-  - build-lambda
-  command: .buildkite/steps/github-release.sh
-  env:
-    BUILDKITE_AGENT_GIT_FETCH_FLAGS: -v --prune --tags
-  plugins:
-  - aws-assume-role-with-web-identity:
-      role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-buildkite-agent-scaler
-  - aws-ssm#v1.0.0:
-      parameters:
-        GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite/buildkite-agent-scaler/GITHUB_RELEASE_ACCESS_TOKEN
-  - docker#v5.8.0:
-      image: alpine:3.18
-      propagate-environment: true
-      mount-buildkite-agent: true
-      environment:
-      - GITHUB_RELEASE_ACCESS_TOKEN
-      - BUILDKITE_AGENT_ACCESS_TOKEN
+  - if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
+    label: ":github: Draft GitHub Release"
+    key: github-release
+    depends_on:
+      - build-lambda
+    command: .buildkite/steps/github-release.sh
+    env:
+      BUILDKITE_AGENT_GIT_FETCH_FLAGS: -v --prune --tags
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-buildkite-agent-scaler
+      - aws-ssm#v1.0.0:
+          parameters:
+            GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite/buildkite-agent-scaler/GITHUB_RELEASE_ACCESS_TOKEN
+      - docker#v5.8.0:
+          image: alpine:3.18
+          propagate-environment: true
+          mount-buildkite-agent: true
+          environment:
+            - GITHUB_RELEASE_ACCESS_TOKEN
+            - BUILDKITE_AGENT_ACCESS_TOKEN
 
-- if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
-  key: block-s3-release
-  block: ":rocket: Draft :github: Release Approved?"
+  - if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
+    key: block-s3-release
+    block: ":rocket: Draft :github: Release Approved?"
 
-- if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
-  label: ":s3: Publish to S3 Release Location"
-  key: s3-release
-  depends_on:
-  - github-release
-  - block-s3-release
-  command: .buildkite/steps/upload-to-s3.sh release
-  plugins:
-  - aws-assume-role-with-web-identity:
-      role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler
+  - if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
+    label: ":s3: Publish to S3 Release Location"
+    key: s3-release
+    depends_on:
+      - github-release
+      - block-s3-release
+    command: .buildkite/steps/upload-to-s3.sh release
+    plugins:
+      - aws-assume-role-with-web-identity:
+          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-GO111MODULE=off go get gotest.tools/gotestsum
+go install gotest.tools/gotestsum@v1.12.0
 
 echo '+++ Running tests'
 gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast ./...

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ bootstrap: lambda/main.go
 		--user $(USER) \
 		--volume $(PWD):/app \
 		--workdir /app \
-		--rm golang:1.19 \
+		--rm \
+		golang:1.22 \
 		go build -ldflags="$(LD_FLAGS)" -buildvcs="$(BUILDVSC_FLAG)" -tags lambda.norpc -o bootstrap ./lambda
 
 lambda-sync: handler.zip

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/buildkite/buildkite-agent-scaler
 
-go 1.19
+go 1.22
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0
-	github.com/aws/aws-sdk-go v1.54.14
+	github.com/aws/aws-sdk-go v1.54.19
 )
 
 require github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,10 @@
 github.com/aws/aws-lambda-go v1.47.0 h1:0H8s0vumYx/YKs4sE7YM0ktwL2eWse+kfopsRI1sXVI=
 github.com/aws/aws-lambda-go v1.47.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go v1.54.14 h1:llJ60MzLzovyDE/rEDbUjS1cICh7krk1PwQwNlKRoeQ=
-github.com/aws/aws-sdk-go v1.54.14/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/aws/aws-sdk-go v1.54.19 h1:tyWV+07jagrNiCcGRzRhdtVjQs7Vy41NwsuOcl0IbVI=
+github.com/aws/aws-sdk-go v1.54.19/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
@@ -12,7 +13,9 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lambda/env.go
+++ b/lambda/env.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+// RequireEnvString reads an environment variable, and if it is not set, calls
+// [log.Fatalf].
+func RequireEnvString(name string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		log.Fatalf("%s is required", name)
+	}
+	return v
+}
+
+// RequireEnvInt reads an environment variable and parses it as a decimal int.
+// If it is not set or does not parse, it calls [log.Fatalf].
+func RequireEnvInt(name string) int {
+	v := RequireEnvString(name)
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		log.Fatalf("%s must be an integer: %v", name, err)
+	}
+	return i
+}
+
+// EnvInt reads an environment variable, and if it is set, parses it with
+// [strconv.Atoi].If it is not set, it returns def. If it does not parse, it calls
+// [log.Fatalf].
+func EnvInt(name string, def int) int {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		log.Fatalf("%s must be an integer: %v", name, err)
+	}
+	return i
+}
+
+// EnvDuration reads an environment variable, and if it is set, parses it as a
+// [time.Duration]. If it is not set, it returns def. If parsing fails, it calls
+// [log.Fatalf].
+func EnvDuration(name string, def time.Duration) time.Duration {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Fatalf("%s must be a duration: %v", name, err)
+	}
+	return d
+}
+
+// EnvFloat reads an environment variable, and if it is set, parses it using
+// [strconv.ParseFloat]. If it is not set, it returns 0. If parsing fails, it
+// calls [log.Fatalf].
+func EnvFloat(name string) float64 {
+	v := os.Getenv(name)
+	if v == "" {
+		return 0
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		log.Fatalf("%s must be a number: %v", name, err)
+	}
+	return f
+}
+
+// EnvBool reads an environment variable, and if it is set, parses it using
+// [strconv.ParseBool]. If it is not set, it returns false. If parsing fails, it
+// calls [log.Fatalf].
+func EnvBool(name string) bool {
+	v := os.Getenv(name)
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		log.Fatalf("%s must be a boolean: %v", name, err)
+	}
+	return b
+}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -81,69 +81,75 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	)
 
 	if v := os.Getenv("LAMBDA_INTERVAL"); v != "" {
-		if interval, err = time.ParseDuration(v); err != nil {
+		d, err := time.ParseDuration(v)
+		if err != nil {
 			return "", err
 		}
+		interval = d
 	}
 
 	if v := os.Getenv("LAMBDA_TIMEOUT"); v != "" {
-		if timeoutDuration, err := time.ParseDuration(v); err != nil {
+		d, err := time.ParseDuration(v)
+		if err != nil {
 			return "", err
-		} else {
-			timeout = time.After(timeoutDuration)
 		}
+		timeout = time.After(d)
 	}
 
 	if v := os.Getenv("ASG_ACTIVITY_TIMEOUT"); v != "" {
-		if timeoutDuration, err := time.ParseDuration(v); err != nil {
+		d, err := time.ParseDuration(v)
+		if err != nil {
 			return "", err
-		} else {
-			asgActivityTimeoutDuration = timeoutDuration
 		}
+		asgActivityTimeoutDuration = d
 	}
 
 	if v := os.Getenv("SCALE_IN_COOLDOWN_PERIOD"); v != "" {
-		if scaleInCooldownPeriod, err = time.ParseDuration(v); err != nil {
+		p, err := time.ParseDuration(v)
+		if err != nil {
 			return "", err
 		}
+		scaleInCooldownPeriod = p
 	}
 
 	if v := os.Getenv("SCALE_IN_FACTOR"); v != "" {
-		if scaleInFactor, err = strconv.ParseFloat(v, 64); err != nil {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
 			return "", err
 		}
-		scaleInFactor = math.Abs(scaleInFactor)
+		scaleInFactor = math.Abs(f)
 	}
 
 	if v := os.Getenv("SCALE_ONLY_AFTER_ALL_EVENT"); v != "" {
-		if v == "true" || v == "1" {
-			scaleOnlyAfterAllEvent = true
-		}
+		scaleOnlyAfterAllEvent = v == "true" || v == "1"
 	}
 
 	if v := os.Getenv("SCALE_OUT_COOLDOWN_PERIOD"); v != "" {
-		if scaleOutCooldownPeriod, err = time.ParseDuration(v); err != nil {
+		p, err := time.ParseDuration(v)
+		if err != nil {
 			return "", err
 		}
+		scaleOutCooldownPeriod = p
 	}
 
 	if v := os.Getenv("SCALE_OUT_FACTOR"); v != "" {
-		if scaleOutFactor, err = strconv.ParseFloat(v, 64); err != nil {
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
 			return "", err
 		}
-		scaleOutFactor = math.Abs(scaleOutFactor)
+		scaleOutFactor = math.Abs(f)
 	}
 
 	if v := os.Getenv("INCLUDE_WAITING"); v != "" {
-		if v == "true" || v == "1" {
-			includeWaiting = true
-		}
+		includeWaiting = v == "true" || v == "1"
 	}
 
 	if v := os.Getenv("INSTANCE_BUFFER"); v != "" {
-		if instanceBuffer, err = strconv.Atoi(v); err != nil {
+		i, err := strconv.Atoi(v)
+		if err != nil {
 			return "", err
 		}
+		instanceBuffer = i
 	}
 
 	maxDescribeScalingActivitiesPages := -1

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -217,12 +217,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		}
 
 		lastScaleInStr := "never"
-		if scaleInOutput != nil {
+		if scaleInOutput != nil && scaleInOutput.StartTime != nil {
 			lastScaleIn = *scaleInOutput.StartTime
 			lastScaleInStr = lastScaleIn.Format(time.RFC3339Nano)
 		}
 		lastScaleOutStr := "never"
-		if scaleOutOutput != nil {
+		if scaleOutOutput != nil && scaleOutOutput.StartTime != nil {
 			lastScaleOut = *scaleOutOutput.StartTime
 			lastScaleOutStr = lastScaleOut.Format(time.RFC3339Nano)
 		}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -170,7 +170,10 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	}
 
 	// establish an AWS session to be re-used
-	sess := session.New()
+	sess, err := session.NewSession()
+	if err != nil {
+		return "", err
+	}
 
 	// get last scale in and out from asg's activities
 	// This is wrapped in a mutex to avoid multiple outbound requests if the

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -23,6 +23,7 @@ import (
 // On a cold start this will be reset to a zero value
 var (
 	lastScaleMu               sync.Mutex
+	lastScaleTimesFetched     bool
 	lastScaleIn, lastScaleOut time.Time
 )
 
@@ -191,7 +192,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		lastScaleMu.Lock()
 		defer lastScaleMu.Unlock()
 
-		if (disableScaleIn || !lastScaleIn.IsZero()) && (disableScaleOut || !lastScaleOut.IsZero()) {
+		if lastScaleTimesFetched {
 			// We've already fetched the last scaling times that we need.
 			return
 		}
@@ -226,6 +227,8 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			lastScaleOut = *scaleOutOutput.StartTime
 			lastScaleOutStr = lastScaleOut.Format(time.RFC3339Nano)
 		}
+
+		lastScaleTimesFetched = true
 
 		scalingTimeDiff := time.Since(scalingLastActivityStartTime)
 		log.Printf("Succesfully retrieved last scaling activity events. Last scale out %s, last scale in %s. Discovery took %s.", lastScaleOutStr, lastScaleInStr, scalingTimeDiff)

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -293,7 +293,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		lastScaleIn = scaler.LastScaleIn()
 		lastScaleOut = scaler.LastScaleOut()
 
-		log.Printf("Waiting for %v\n", interval)
+		log.Printf("Waiting for %v or timeout", interval)
 		select {
 		case <-timeout:
 			return "", nil

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -226,11 +226,11 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	ssmTokenKey := os.Getenv("BUILDKITE_AGENT_TOKEN_SSM_KEY")
 
 	if ssmTokenKey != "" {
-		var err error
-		token, err = scaler.RetrieveFromParameterStore(sess, ssmTokenKey)
+		tk, err := scaler.RetrieveFromParameterStore(sess, ssmTokenKey)
 		if err != nil {
 			return "", err
 		}
+		token = tk
 	}
 
 	if token == "" {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -207,15 +207,19 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			return
 		}
 
+		lastScaleInStr := "never"
 		if scaleInOutput != nil {
 			lastScaleIn = *scaleInOutput.StartTime
+			lastScaleInStr = lastScaleIn.Format(time.RFC3339Nano)
 		}
+		lastScaleOutStr := "never"
 		if scaleOutOutput != nil {
 			lastScaleOut = *scaleOutOutput.StartTime
+			lastScaleOutStr = lastScaleOut.Format(time.RFC3339Nano)
 		}
 
 		scalingTimeDiff := time.Since(scalingLastActivityStartTime)
-		log.Printf("Succesfully retrieved last scaling activity events. Last scale out %v, last scale in %v. Discovery took %s.", lastScaleOut, lastScaleIn, scalingTimeDiff)
+		log.Printf("Succesfully retrieved last scaling activity events. Last scale out %s, last scale in %s. Discovery took %s.", lastScaleOutStr, lastScaleInStr, scalingTimeDiff)
 	}()
 
 	token := os.Getenv("BUILDKITE_AGENT_TOKEN")

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -68,20 +68,20 @@ func NewScaler(client *buildkite.Client, sess *session.Session, params Params) (
 
 	if params.DryRun {
 		scaler.autoscaling = &dryRunASG{}
-
 		if params.PublishCloudWatchMetrics {
 			scaler.metrics = &dryRunMetricsPublisher{}
 		}
-	} else {
-		scaler.autoscaling = &ASGDriver{
-			Name: params.AutoScalingGroupName,
-			Sess: sess,
-		}
+		return scaler, nil
+	}
 
-		if params.PublishCloudWatchMetrics {
-			scaler.metrics = &cloudWatchMetricsPublisher{
-				sess: sess,
-			}
+	scaler.autoscaling = &ASGDriver{
+		Name: params.AutoScalingGroupName,
+		Sess: sess,
+	}
+
+	if params.PublishCloudWatchMetrics {
+		scaler.metrics = &cloudWatchMetricsPublisher{
+			sess: sess,
 		}
 	}
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -115,7 +115,8 @@ func (s *Scaler) Run() (time.Duration, error) {
 	if desired > asg.MaxSize {
 		log.Printf("⚠️  Desired count exceed MaxSize, capping at %d", asg.MaxSize)
 		desired = asg.MaxSize
-	} else if desired < asg.MinSize {
+	}
+	if desired < asg.MinSize {
 		log.Printf("⚠️  Desired count is less than MinSize, capping at %d", asg.MinSize)
 		desired = asg.MinSize
 	}

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -143,7 +143,7 @@ func (s *Scaler) scaleIn(desired int64, current AutoscaleGroupDetails) error {
 		lastScaleInEvent := s.scaleInParams.LastEvent
 		lastScaleOutEvent := s.scaleOutParams.LastEvent
 		lastEvent := lastScaleInEvent
-		if s.scaleOnlyAfterAllEvent == true && lastScaleInEvent.Before(lastScaleOutEvent) {
+		if s.scaleOnlyAfterAllEvent && lastScaleInEvent.Before(lastScaleOutEvent) {
 			lastEvent = lastScaleOutEvent
 		}
 		cooldownRemaining := s.scaleInParams.CooldownPeriod - time.Since(lastEvent)
@@ -162,13 +162,16 @@ func (s *Scaler) scaleIn(desired int64, current AutoscaleGroupDetails) error {
 		// Use Floor to avoid never reaching upper bound
 		factoredChange := int64(math.Floor(float64(change) * factor))
 
-		if factoredChange < change {
+		switch {
+		case factoredChange < change:
 			log.Printf("👮‍️ Increasing scale-in of %d by factor of %0.2f",
 				change, factor)
-		} else if factoredChange > change {
+
+		case factoredChange > change:
 			log.Printf("👮‍️ Decreasing scale-in of %d by factor of %0.2f",
 				change, factor)
-		} else {
+
+		default:
 			log.Printf("👮‍️ Scale-in factor of %0.2f was ignored",
 				factor)
 		}
@@ -206,7 +209,7 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 		lastScaleInEvent := s.scaleInParams.LastEvent
 		lastScaleOutEvent := s.scaleOutParams.LastEvent
 		lastEvent := lastScaleOutEvent
-		if s.scaleOnlyAfterAllEvent == true && lastScaleOutEvent.Before(lastScaleInEvent) {
+		if s.scaleOnlyAfterAllEvent && lastScaleOutEvent.Before(lastScaleInEvent) {
 			lastEvent = lastScaleInEvent
 		}
 		cooldownRemaining := s.scaleOutParams.CooldownPeriod - time.Since(lastEvent)
@@ -225,13 +228,16 @@ func (s *Scaler) scaleOut(desired int64, current AutoscaleGroupDetails) error {
 		// Use Ceil to avoid never reaching upper bound
 		factoredChange := int64(math.Ceil(float64(change) * s.scaleOutParams.Factor))
 
-		if factoredChange > change {
+		switch {
+		case factoredChange > change:
 			log.Printf("👮‍️ Increasing scale-out of %d by factor of %0.2f",
 				change, s.scaleOutParams.Factor)
-		} else if factoredChange < change {
+
+		case factoredChange < change:
 			log.Printf("👮‍️ Decreasing scale-out of %d by factor of %0.2f",
 				change, s.scaleOutParams.Factor)
-		} else {
+
+		default:
 			log.Printf("👮‍️ Scale-out factor of %0.2f was ignored",
 				s.scaleOutParams.Factor)
 		}


### PR DESCRIPTION
This is a grab-bag of code cleanups.

The only significant change should be that `scaler.Run` now happens before checking `timeout`, so the lambda won't time out before it does anything useful (regardless of `LAMBDA_TIMEOUT`).