### PR TITLE
Update Go to 1.22 in the SAR pipeline

### DIFF
--- a/.buildkite/pipeline-sar.yaml
+++ b/.buildkite/pipeline-sar.yaml
@@ -4,7 +4,7 @@ steps:
     command: .buildkite/steps/tests.sh
     plugins:
       - docker#v3.1.0:
-          image: "golang:1.19"
+          image: "golang:1.22"
           workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
 
   - name: ":hammer::lambda: Build Lambda"


### PR DESCRIPTION
The update to Go 1.22 broke this extra pipeline, but it should be an easy fix.