### PR TITLE
Enable subnet and security group configuration in Cloudformation

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -94,6 +94,16 @@ Parameters:
     Type: String
     Description: Minimum time interval between polls. If a larger interval is provided by Buildkite, that is used instead.
     Default: "10s"
+  
+  SecurityGroupIds:
+    Description: "Comma separated list of security group IDs to run the lambda in. Defaults to not configuring security groups."
+    Type: CommaDelimitedList
+    Default: ""
+    
+  SubnetIds:
+    Description: "Comma separated list of subnet IDs to run the lambda in. Defaults to not configuring subnets."
+    Type: CommaDelimitedList
+    Default: ""
 
 Conditions:
   CreateRole:
@@ -102,6 +112,20 @@ Conditions:
     !Not [ !Equals [ !Ref BuildkiteAgentTokenParameterStoreKMSKey, "" ] ]
   SetRolePermissionsBoundaryARN:
     !Not [ !Equals [ !Ref RolePermissionsBoundaryARN, "" ] ]
+  SetSecurityGroups:
+    Fn::Not:
+      - Fn::Equals:
+        - Fn::Join:
+           - ""
+           - Ref: SecurityGroupIds
+        - ""
+  SetSubnets:
+    Fn::Not:
+      - Fn::Equals:
+        - Fn::Join:
+           - ""
+           - Ref: SubnetIds
+        - ""
 
 Mappings:
   LambdaBucket:
@@ -195,6 +219,9 @@ Resources:
       Architectures:
         - x86_64
       MemorySize: 128
+      VpcConfig:
+        SecurityGroupIds: !If [ SetSecurityGroups, !Split [',', !Join [',', !Ref SecurityGroupIds]], !Ref "AWS::NoValue" ]
+        SubnetIds: !If [ SetSubnets, !Split [',', !Join [',', !Ref SubnetIds]], !Ref "AWS::NoValue" ]
       Environment:
         Variables:
           BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenParameter


### PR DESCRIPTION
We are currently trying to configure restrictions on the agent token by IP address, re: https://buildkite.com/docs/clusters/manage-clusters#restrict-an-agent-tokens-access-by-ip-address

In order to do this, we need the ability to configure the Lambda to run within dedicated subnet(s). This PR enables this, while not changing the behavior by default for others. I've tested this and not suppyling the new security group and subnet values, results in a non-VPC-associated Lambda. 

Note: We are not using the Elastic CI stack. Our use case required us to deploy this Lambda via https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/serverlessapplicationrepository_cloudformation_stack . With that in mind, we likely wouldn't be pursuing a followup PR to enable this for users of Elastic CI stack (i.e. giving folks the ability to thread the subnet IDs and security groups through to the nested stack from this repo)