### PR TITLE
Update the role used to publish SAR

### DIFF
--- a/.buildkite/pipeline-sar.yaml
+++ b/.buildkite/pipeline-sar.yaml
@@ -31,5 +31,5 @@ steps:
     depends_on:
       - release
     plugins:
-      - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-agent-scaler-publish
+      - aws-assume-role-with-web-identity#v1.1.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-buildkite-agent-scaler-publish


### PR DESCRIPTION
The new roel has the same permissions, only the name has changed