### PR TITLE
Assume an IAM role for publishing to SAR S3 bucket

### DIFF
--- a/.buildkite/pipeline-sar.yaml
+++ b/.buildkite/pipeline-sar.yaml
@@ -19,6 +19,9 @@ steps:
     depends_on:
       - test
       - build
+    plugins:
+      - aws-assume-role-with-web-identity#v1.1.0:
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-buildkite-agent-scaler-publish
 
   - block: ":package::arrow_right::rocket: Draft :github: Release Approved?"
     key: release


### PR DESCRIPTION
This is our preferred pattern for interacting with AWS in pipelines, rather than relying on the instance role.