### PR TITLE
Update release process to assume new IAM roles via OIDC

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -34,7 +34,7 @@ steps:
     command: .buildkite/steps/upload-to-s3.sh
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-scaler
 
   - if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
     label: ":github: Draft GitHub Release"
@@ -71,4 +71,4 @@ steps:
     command: .buildkite/steps/upload-to-s3.sh release
     plugins:
       - aws-assume-role-with-web-identity:
-          role-arn: arn:aws:iam::032379705303:role/pipeline-buildkite-buildkite-agent-scaler
+          role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-scaler

--- a/.buildkite/steps/upload-to-s3.sh
+++ b/.buildkite/steps/upload-to-s3.sh
@@ -4,28 +4,6 @@ set -euo pipefail
 
 export AWS_DEFAULT_REGION=us-east-1
 
-EXTRA_REGIONS=(
-  us-east-2
-  us-west-1
-  us-west-2
-  af-south-1
-  ap-east-1
-  ap-south-1
-  ap-northeast-2
-  ap-northeast-1
-  ap-southeast-2
-  ap-southeast-1
-  ca-central-1
-  eu-central-1
-  eu-west-1
-  eu-west-2
-  eu-south-1
-  eu-west-3
-  eu-north-1
-  me-south-1
-  sa-east-1
-)
-
 VERSION="v${BUILDKITE_TAG#v}"
 BASE_BUCKET=buildkite-lambdas
 BUCKET_PATH=buildkite-agent-scaler
@@ -40,10 +18,4 @@ echo "~~~ :buildkite: Downloading artifacts"
 buildkite-agent artifact download handler.zip .
 
 echo "~~~ :s3: Uploading lambda to ${BASE_BUCKET}/${BUCKET_PATH}/ in ${AWS_DEFAULT_REGION}"
-aws s3 cp --acl public-read handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"
-
-for region in "${EXTRA_REGIONS[@]}"; do
-  bucket="${BASE_BUCKET}-${region}"
-  echo "~~~ :s3: Copying files to ${bucket}"
-  aws --region "${region}" s3 cp --acl public-read "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip" "s3://${bucket}/${BUCKET_PATH}/handler.zip"
-done
+aws s3 cp handler.zip "s3://${BASE_BUCKET}/${BUCKET_PATH}/handler.zip"


### PR DESCRIPTION
We recently moved the S3 buckets that host our public lambdas to a new AWS account, and the OIDC assumable IAM roles for publishing to the buckets moved with them.

The replacement buckets have the same name, so we don't need to change them. However the recreated buckets use BucketOwnerEnforced for ownership and resource policies for access, instead of ACLs. We need to remove `--acl` from the upload command.