### PR TITLE
Add an option to override the agent endpoint URL via flag and env var

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -13,8 +13,7 @@ import (
 )
 
 const (
-	DefaultMetricsEndpoint = "https://agent.buildkite.com/v3"
-	PollDurationHeader     = "Buildkite-Agent-Metrics-Poll-Duration"
+	PollDurationHeader = "Buildkite-Agent-Metrics-Poll-Duration"
 )
 
 type Client struct {
@@ -23,9 +22,9 @@ type Client struct {
 	UserAgent  string
 }
 
-func NewClient(agentToken string) *Client {
+func NewClient(agentToken, agentEndpoint string) *Client {
 	return &Client{
-		Endpoint:   DefaultMetricsEndpoint,
+		Endpoint:   agentEndpoint,
 		UserAgent:  fmt.Sprintf("buildkite-agent-scaler/%s", version.VersionString()),
 		AgentToken: agentToken,
 	}

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -12,7 +12,7 @@ func TestHappy(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		io.WriteString(w, `{"organization": {"slug": "llamacorp"}}`)
 	}))
-	c := NewClient("testtoken")
+	c := NewClient("testtoken", "https://agent.buildkite.com/v3")
 	c.Endpoint = s.URL
 	m, err := c.GetAgentMetrics("default")
 	if err != nil {
@@ -29,7 +29,7 @@ func TestUnauthorizedResponse(t *testing.T) {
 		w.WriteHeader(http.StatusUnauthorized)
 		io.WriteString(w, `{"message": "Eeep! You forgot to pass an agent registration token"}`)
 	}))
-	c := NewClient("testtoken")
+	c := NewClient("testtoken", "https://agent.buildkite.com/v3")
 	c.Endpoint = s.URL
 	_, err := c.GetAgentMetrics("default")
 	if err != nil {

--- a/lambda/env.go
+++ b/lambda/env.go
@@ -28,6 +28,16 @@ func RequireEnvInt(name string) int {
 	return i
 }
 
+// EnvString reads an environment variable, and if it is not set, returns def.
+func EnvString(name, def string) string {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+
+	return v
+}
+
 // EnvInt reads an environment variable, and if it is set, parses it with
 // [strconv.Atoi].If it is not set, it returns def. If it does not parse, it calls
 // [log.Fatalf].

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -39,6 +39,9 @@ func main() {
 func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	log.Printf("buildkite-agent-scaler version %s", version.VersionString())
 
+	// optional agent endpoint
+	buildkiteAgentEndpoint := EnvString("BUILDKITE_AGENT_ENDPOINT", "https://agent.buildkite.com/v3")
+
 	// Required environment variables
 	buildkiteQueue := RequireEnvString("BUILDKITE_QUEUE")
 	asgName := RequireEnvString("ASG_NAME")
@@ -148,7 +151,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		return "", errors.New("Must provide either BUILDKITE_AGENT_TOKEN or BUILDKITE_AGENT_TOKEN_SSM_KEY")
 	}
 
-	client := buildkite.NewClient(token)
+	client := buildkite.NewClient(token, buildkiteAgentEndpoint)
 	params := scaler.Params{
 		BuildkiteQueue:       buildkiteQueue,
 		AutoScalingGroupName: asgName,

--- a/main.go
+++ b/main.go
@@ -19,9 +19,10 @@ func main() {
 		ssmTokenKey       = flag.String("agent-token-ssm-key", "", "The AWS SSM Parameter Store key for the agent token")
 
 		// buildkite params
-		buildkiteQueue      = flag.String("queue", "default", "The queue to watch in the metrics")
-		buildkiteAgentToken = flag.String("agent-token", "", "A buildkite agent registration token")
-		includeWaiting      = flag.Bool("include-waiting", false, "Whether to include jobs behind a wait step for scaling")
+		buildkiteAgentEndpoint = flag.String("agent-endpoint", "https://agent.buildkite.com/v3", "The buildkite agent API endpoint")
+		buildkiteQueue         = flag.String("queue", "default", "The queue to watch in the metrics")
+		buildkiteAgentToken    = flag.String("agent-token", "", "A buildkite agent registration token")
+		includeWaiting         = flag.Bool("include-waiting", false, "Whether to include jobs behind a wait step for scaling")
 
 		// scale in/out params
 		scaleInFactor  = flag.Float64("scale-in-factor", 1.0, "A factor to apply to scale ins")
@@ -46,7 +47,7 @@ func main() {
 		buildkiteAgentToken = &token
 	}
 
-	client := buildkite.NewClient(*buildkiteAgentToken)
+	client := buildkite.NewClient(*buildkiteAgentToken, *buildkiteAgentEndpoint)
 
 	scaler, err := scaler.NewScaler(client, sess, scaler.Params{
 		BuildkiteQueue:           *buildkiteQueue,

--- a/template.yaml
+++ b/template.yaml
@@ -12,6 +12,11 @@ Parameters:
     Type: String
     Default: ""
 
+  AgentEndpoint:
+    Description: Override API endpoint the Buildkite Agent connects to.
+    Type: String
+    Default: "https://agent.buildkite.com/v3"
+
   BuildkiteQueue:
     Description: Queue name that agents will use, targeted in pipeline steps using "queue={value}"
     Type: String
@@ -224,6 +229,7 @@ Resources:
         SubnetIds: !If [ SetSubnets, !Split [',', !Join [',', !Ref SubnetIds]], !Ref "AWS::NoValue" ]
       Environment:
         Variables:
+          BUILDKITE_AGENT_ENDPOINT:      !Ref AgentEndpoint
           BUILDKITE_AGENT_TOKEN_SSM_KEY: !Ref BuildkiteAgentTokenParameter
           BUILDKITE_QUEUE:               !Ref BuildkiteQueue
           AGENTS_PER_INSTANCE:           !Ref AgentsPerInstance


### PR DESCRIPTION
I have this new endpoint in a way that always defaults to https://agent.buildkite.com/v3 if not provided to ensure compability with old installations or forks.

I used `AgentEndpoint` for the param name in the template as it matches the name in the elastic stack template.