### PR TITLE
fix: correct permissions to handle instances in ElasticCIMode

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -251,15 +251,27 @@ Resources:
                     - ssm:SendCommand
                     - ssm:GetCommandInvocation
                   Resource: '*'
+                - Effect: Allow
+                  Action:
+                    - ssm:SendCommand
+                    - ssm:GetCommandInvocation
+                  Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
                   Condition:
-                    StringEquals:
-                      "ec2:ResourceTag/aws:autoscaling:groupName": !Ref AgentAutoScaleGroup
+                    StringLike:
+                      "ec2:ResourceTag/aws:autoscaling:groupName": !Sub "${AWS::StackName}-AgentAutoScaleGroup-*"
                 - Effect: Allow
                   Action:
                     - ssm:DescribeInstanceInformation
                     - ec2:DescribeInstanceStatus
                     - ec2:DescribeInstances
                   Resource: '*'
+                - Effect: Allow
+                  Action:
+                    - ec2:TerminateInstances
+                  Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+                  Condition:
+                    StringLike:
+                      "ec2:ResourceTag/aws:autoscaling:groupName": !Sub "${AWS::StackName}-AgentAutoScaleGroup-*"
           - !Ref 'AWS::NoValue'
 
   AutoscalingFunction:


### PR DESCRIPTION
Fix IAM role used by the agent-scaler in ElasticCIMode (introduced in https://github.com/buildkite/buildkite-agent-scaler/pull/212), so it can send SIGTERM (graceful scale-in), and terminate Elastic Stack's EC2 instances when dangling instances detected.

Verified with my own stack just now.