### PR TITLE
fix: scope down ElasticCIModeSSMAndEC2 policy

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -250,15 +250,17 @@ Resources:
                   Action:
                     - ssm:SendCommand
                     - ssm:GetCommandInvocation
-                  Resource: '*'
+                  Resource:
+                    - !Sub "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
                 - Effect: Allow
                   Action:
                     - ssm:SendCommand
                     - ssm:GetCommandInvocation
                   Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
                   Condition:
-                    StringLike:
-                      "ec2:ResourceTag/aws:autoscaling:groupName": !Sub "${AWS::StackName}-AgentAutoScaleGroup-*"
+                    StringEquals:
+                      "ssm:resourceTag/Role": "buildkite-agent"
+                      "ssm:resourceTag/aws:autoscaling:groupName": !Ref AgentAutoScaleGroup
                 - Effect: Allow
                   Action:
                     - ssm:DescribeInstanceInformation
@@ -270,8 +272,9 @@ Resources:
                     - ec2:TerminateInstances
                   Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
                   Condition:
-                    StringLike:
-                      "ec2:ResourceTag/aws:autoscaling:groupName": !Sub "${AWS::StackName}-AgentAutoScaleGroup-*"
+                    StringEquals:
+                      "ec2:ResourceTag/Role": "buildkite-agent"
+                      "ec2:ResourceTag/aws:autoscaling:groupName": !Ref AgentAutoScaleGroup
           - !Ref 'AWS::NoValue'
 
   AutoscalingFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -247,20 +247,19 @@ Resources:
               Version: '2012-10-17'
               Statement:
                 - Effect: Allow
-                  Action:
-                    - ssm:SendCommand
-                    - ssm:GetCommandInvocation
+                  Action: ssm:SendCommand
                   Resource:
                     - !Sub "arn:aws:ssm:${AWS::Region}::document/AWS-RunShellScript"
                 - Effect: Allow
-                  Action:
-                    - ssm:SendCommand
-                    - ssm:GetCommandInvocation
+                  Action: ssm:SendCommand
                   Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
                   Condition:
                     StringEquals:
                       "ssm:resourceTag/Role": "buildkite-agent"
                       "ssm:resourceTag/aws:autoscaling:groupName": !Ref AgentAutoScaleGroup
+                - Effect: Allow
+                  Action: ssm:GetCommandInvocation
+                  Resource: "*"
                 - Effect: Allow
                   Action:
                     - ssm:DescribeInstanceInformation


### PR DESCRIPTION
As per [https://docs.aws.amazon.com/systems-manager/latest/userguide/run-command-setting-up.html#tag-based-access](https://docs.aws.amazon.com/systems-manager/latest/userguide/run-command-setting-up.html#tag-based-access), we need two statements to restrict SSM command runs.

1. `ssm:SendCommand` and `ssm:GetCommandInvocation` are now conditional on target EC2 instances possessing **both**:    
    - `Role: buildkite-agent` tag
    - `aws:autoscaling:groupName` tag matching the `!Ref AgentAutoScaleGroup` parameter passed down from the Elastic CI Stack CloudFormation Stack
2. `ec2:TerminateInstances` is now conditional on target EC2 instances possessing **both**:
    - `Role: buildkite-agent`
    - `aws:autoscaling:groupName` tag matching the `!Ref AgentAutoScaleGroup` parameter passed down from the Elastic CI Stack CloudFormation Stack