### PR TITLE
feat: update tooling to use mise

### DIFF
--- a/.buildkite/pipeline-sar.yaml
+++ b/.buildkite/pipeline-sar.yaml
@@ -1,15 +1,24 @@
+# YAML anchor for mise setup
+x-mise-setup: &mise-setup |
+  if [[ ! -f ./bin/mise ]]; then
+    mkdir -p ./bin
+    curl -fsSL https://mise.jdx.dev/mise-latest-linux-x64 > ./bin/mise
+    chmod +x ./bin/mise
+  fi
+  ./bin/mise install
+
 steps:
   - name: ":golang: Tests"
     key: test
-    command: .buildkite/steps/tests.sh
-    plugins:
-      - docker#v3.1.0:
-          image: "golang:1.24"
-          workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
+    commands:
+      - *mise-setup
+      - .buildkite/steps/tests.sh
 
   - name: ":hammer::lambda: Build Lambda"
     key: build
-    command: .buildkite/steps/build-lambda.sh
+    commands:
+      - *mise-setup
+      - .buildkite/steps/build-lambda.sh
     artifact_paths:
       - handler.zip
 

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,28 +1,35 @@
 agents:
   queue: elastic-runners
 
+# YAML anchor for mise setup
+x-mise-setup: &mise-setup |
+  if [[ ! -f ./bin/mise ]]; then
+    mkdir -p ./bin
+    curl -fsSL https://mise.jdx.dev/mise-latest-linux-x64 > ./bin/mise
+    chmod +x ./bin/mise
+  fi
+  ./bin/mise install
+
 steps:
   - name: ":go: Check go fmt"
     key: go-fmt
-    command: .buildkite/steps/test-go-fmt.sh
-    plugins:
-      - docker#v5.8.0:
-          image: golang:1.24
-          workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
+    commands:
+      - *mise-setup
+      - .buildkite/steps/test-go-fmt.sh
 
   - name: ":golang: Run Tests"
     key: test
-    command: .buildkite/steps/tests.sh
-    plugins:
-      - docker#v5.8.0:
-          image: golang:1.24
-          workdir: /go/src/github.com/buildkite/buildkite-agent-scaler
+    commands:
+      - *mise-setup
+      - .buildkite/steps/tests.sh
 
   - name: ":lambda: Build Lambda"
     key: build-lambda
     depends_on:
       - go-fmt
-    command: .buildkite/steps/build-lambda.sh
+    commands:
+      - *mise-setup
+      - .buildkite/steps/build-lambda.sh
     artifact_paths:
       - handler.zip
 

--- a/.buildkite/steps/test-go-fmt.sh
+++ b/.buildkite/steps/test-go-fmt.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-if [[ $(gofmt -l ./ | head -c 1 | wc -c) != 0 ]]; then
+if [[ $(./bin/mise exec -- gofmt -l ./ | head -c 1 | wc -c) != 0 ]]; then
   echo "The following files haven't been formatted with \`go fmt\`:"
-  gofmt -l ./
+  ./bin/mise exec -- gofmt -l ./
   echo
   echo "Fix this by running \`go fmt ./...\` locally, and committing the result."
   exit 1

--- a/.buildkite/steps/tests.sh
+++ b/.buildkite/steps/tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 set -euo pipefail
 
-go install gotest.tools/gotestsum@v1.12.0
-
 echo '+++ Running tests'
-gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast ./...
+./bin/mise exec -- gotestsum --junitfile "junit-${OSTYPE}.xml" -- -count=1 -failfast ./...

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,10 @@ handler.zip: bootstrap
 	zip -9 -v -j $@ "$<"
 
 bootstrap: lambda/main.go
-	docker run \
-	  --env GOCACHE=/go/cache \
-	  --env CGO_ENABLED \
-	  --user $(USER) \
-	  --volume $(PWD):/app \
-	  --workdir /app \
-	  --rm \
-	  golang:1.24 \
-	  go build \
+	./bin/mise install
+	./bin/mise exec -- go build \
 	    -ldflags="$(LD_FLAGS)" \
-	    -buildvcs="$(BUILDVSC_FLAG)" \
+	    -buildvcs="$(BUILDVCS_FLAG)" \
 	    -tags lambda.norpc \
 	    -o bootstrap \
 	    ./lambda

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See the [forum post](https://forum.buildkite.community/t/experimental-lambda-bas
 
 ## Publishing Cloudwatch Metrics
 
-The scaler collects it's own metrics and doesn't require [buildkite-agent-metrics][]. It supports
+The scaler collects its own metrics and doesn't require [buildkite-agent-metrics][]. It supports
 optionally publishing the metrics it collects back to Cloudwatch, although it only supports a subset
 of the metrics that the [buildkite-agent-metrics][] binary collects:
 
@@ -81,10 +81,15 @@ aws lambda create-function \
   --handler bootstrap
 ```
 
-## Running locally for development
+## Development
+This project uses [mise](https://mise.jdx.dev/) to manage development tooling ensuring all the tooling needed is installed with one step, and in expected versions.
+To install mise, execute [./bin/mise](./bin/mise) bootstrap script or follow [mise documentation](https://mise.jdx.dev/installing-mise.html). 
+Run `mise install` to install all the required tooling defined in [mise.toml](./mise.toml).
+
+### Running agent-scaler locally
 
 ```
-$ aws-vault exec my-profile -- go run . \
+$ mise exec go -- go run . \
   --asg-name elastic-runners-AgentAutoScaleGroup-XXXXX
   --agent-token "$BUILDKITE_AGENT_TOKEN"
 ```

--- a/bin/mise
+++ b/bin/mise
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+set -eu
+
+__mise_bootstrap() {
+    local script_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+    local project_dir=$( cd -- "$( dirname -- "$script_dir" )" &> /dev/null && pwd )
+    export MISE_BOOTSTRAP_PROJECT_DIR="$project_dir"
+    local cache_home="${XDG_CACHE_HOME:-$HOME/.cache}/mise"
+    export MISE_INSTALL_PATH="$cache_home/mise-2025.6.4"
+    install() {
+        #!/bin/sh
+        set -eu
+
+        #region logging setup
+        if [ "${MISE_DEBUG-}" = "true" ] || [ "${MISE_DEBUG-}" = "1" ]; then
+          debug() {
+            echo "$@" >&2
+          }
+        else
+          debug() {
+            :
+          }
+        fi
+
+        if [ "${MISE_QUIET-}" = "1" ] || [ "${MISE_QUIET-}" = "true" ]; then
+          info() {
+            :
+          }
+        else
+          info() {
+            echo "$@" >&2
+          }
+        fi
+
+        error() {
+          echo "$@" >&2
+          exit 1
+        }
+        #endregion
+
+        #region environment setup
+        get_os() {
+          os="$(uname -s)"
+          if [ "$os" = Darwin ]; then
+            echo "macos"
+          elif [ "$os" = Linux ]; then
+            echo "linux"
+          else
+            error "unsupported OS: $os"
+          fi
+        }
+
+        get_arch() {
+          musl=""
+          if type ldd >/dev/null 2>/dev/null; then
+            libc=$(ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
+            if [ -n "$libc" ]; then
+              musl="-musl"
+            fi
+          fi
+          arch="$(uname -m)"
+          if [ "$arch" = x86_64 ]; then
+            echo "x64$musl"
+          elif [ "$arch" = aarch64 ] || [ "$arch" = arm64 ]; then
+            echo "arm64$musl"
+          elif [ "$arch" = armv7l ]; then
+            echo "armv7$musl"
+          else
+            error "unsupported architecture: $arch"
+          fi
+        }
+
+        get_ext() {
+          if [ -n "${MISE_INSTALL_EXT:-}" ]; then
+            echo "$MISE_INSTALL_EXT"
+          elif [ -n "${MISE_VERSION:-}" ] && echo "$MISE_VERSION" | grep -q '^v2024'; then
+            # 2024 versions don't have zstd tarballs
+            echo "tar.gz"
+          elif tar_supports_zstd; then
+            echo "tar.zst"
+          elif command -v zstd >/dev/null 2>&1; then
+            echo "tar.zst"
+          else
+            echo "tar.gz"
+          fi
+        }
+
+        tar_supports_zstd() {
+          # tar is bsdtar or version is >= 1.31
+          if tar --version | grep -q 'bsdtar' && command -v zstd >/dev/null 2>&1; then
+            true
+          elif tar --version | grep -q '1\.(3[1-9]|[4-9][0-9]'; then
+            true
+          else
+            false
+          fi
+        }
+
+        shasum_bin() {
+          if command -v shasum >/dev/null 2>&1; then
+            echo "shasum"
+          elif command -v sha256sum >/dev/null 2>&1; then
+            echo "sha256sum"
+          else
+            error "mise install requires shasum or sha256sum but neither is installed. Aborting."
+          fi
+        }
+
+        get_checksum() {
+          version=$1
+          os="$(get_os)"
+          arch="$(get_arch)"
+          ext="$(get_ext)"
+          url="https://github.com/jdx/mise/releases/download/v${version}/SHASUMS256.txt"
+
+          # For current version use static checksum otherwise
+          # use checksum from releases
+          if [ "$version" = "v2025.6.4" ]; then
+            checksum_linux_x86_64="609f8b24e2c5208124ceddfa79c9b428efc36af239ca79db5da140ee965a1834  ./mise-v2025.6.4-linux-x64.tar.gz"
+            checksum_linux_x86_64_musl="50deeb8b60c9d725d10a53b2a5772b685bf401c3008791a168fcdb829363e67d  ./mise-v2025.6.4-linux-x64-musl.tar.gz"
+            checksum_linux_arm64="57a45da192ce4ea92f8c06d1cdd37909363345de2767fd2283cdf059fd03c075  ./mise-v2025.6.4-linux-arm64.tar.gz"
+            checksum_linux_arm64_musl="f04a435d01952b45520a5c0ed736d331b3db4c31da03d7d3cc7a215c064a5fad  ./mise-v2025.6.4-linux-arm64-musl.tar.gz"
+            checksum_linux_armv7="fb5f4136ed7c426f95bd4d50c0cd4964f5b17f8f7cb9df72d7a79a978415f00c  ./mise-v2025.6.4-linux-armv7.tar.gz"
+            checksum_linux_armv7_musl="c43c504ca4f486fa529d9b1ee1c0aab2c8308ef07b8569e7f25e0152c256606e  ./mise-v2025.6.4-linux-armv7-musl.tar.gz"
+            checksum_macos_x86_64="067769fdec24631c5e586eb8cbd607da7e47fee4dc3a8a4230d15ebc50f0865d  ./mise-v2025.6.4-macos-x64.tar.gz"
+            checksum_macos_arm64="705b18200adf923c7faae022f35abd0b3e0b1daa271957492168e931ba7e1ed7  ./mise-v2025.6.4-macos-arm64.tar.gz"
+            checksum_linux_x86_64_zstd="98d69e44f811a9611fcb55b90076a40c146c87319b02a0e6deda33df3ed66984  ./mise-v2025.6.4-linux-x64.tar.zst"
+            checksum_linux_x86_64_musl_zstd="60dc830b16fa32efbaee7b0a0340942f7b4a7475c57db2d79f7f7400abe8563b  ./mise-v2025.6.4-linux-x64-musl.tar.zst"
+            checksum_linux_arm64_zstd="29efa155f2cbe70adb9e251caf149b5ca244896be00fde9f13ab535d1430b4f5  ./mise-v2025.6.4-linux-arm64.tar.zst"
+            checksum_linux_arm64_musl_zstd="ece6af08308802943d2dd3c6650b96cf32c64ab4ff00ed4f26a5dd4d62eed867  ./mise-v2025.6.4-linux-arm64-musl.tar.zst"
+            checksum_linux_armv7_zstd="f5c118178964e680114a8a3e8b262d696ee96a6eb934781483fdd1f15b58e545  ./mise-v2025.6.4-linux-armv7.tar.zst"
+            checksum_linux_armv7_musl_zstd="b802df03baf50130c40bc47e43943a79e8879cc8833c58fa7b9ab1fc1fbf6a0e  ./mise-v2025.6.4-linux-armv7-musl.tar.zst"
+            checksum_macos_x86_64_zstd="36b2937732da87611d5aa1fb12b6b9b2f64daf8e90dcbc69b027be6c75b21193  ./mise-v2025.6.4-macos-x64.tar.zst"
+            checksum_macos_arm64_zstd="5bcd0a3aec2576402e5aa79cc3c95afe72500d23455022d1bdb1d7f8846c2abe  ./mise-v2025.6.4-macos-arm64.tar.zst"
+
+            # TODO: refactor this, it's a bit messy
+            if [ "$(get_ext)" = "tar.zst" ]; then
+              if [ "$os" = "linux" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_linux_x86_64_zstd"
+                elif [ "$arch" = "x64-musl" ]; then
+                  echo "$checksum_linux_x86_64_musl_zstd"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_linux_arm64_zstd"
+                elif [ "$arch" = "arm64-musl" ]; then
+                  echo "$checksum_linux_arm64_musl_zstd"
+                elif [ "$arch" = "armv7" ]; then
+                  echo "$checksum_linux_armv7_zstd"
+                elif [ "$arch" = "armv7-musl" ]; then
+                  echo "$checksum_linux_armv7_musl_zstd"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              elif [ "$os" = "macos" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_macos_x86_64_zstd"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_macos_arm64_zstd"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              else
+                warn "no checksum for $os-$arch"
+              fi
+            else
+              if [ "$os" = "linux" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_linux_x86_64"
+                elif [ "$arch" = "x64-musl" ]; then
+                  echo "$checksum_linux_x86_64_musl"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_linux_arm64"
+                elif [ "$arch" = "arm64-musl" ]; then
+                  echo "$checksum_linux_arm64_musl"
+                elif [ "$arch" = "armv7" ]; then
+                  echo "$checksum_linux_armv7"
+                elif [ "$arch" = "armv7-musl" ]; then
+                  echo "$checksum_linux_armv7_musl"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              elif [ "$os" = "macos" ]; then
+                if [ "$arch" = "x64" ]; then
+                  echo "$checksum_macos_x86_64"
+                elif [ "$arch" = "arm64" ]; then
+                  echo "$checksum_macos_arm64"
+                else
+                  warn "no checksum for $os-$arch"
+                fi
+              else
+                warn "no checksum for $os-$arch"
+              fi
+            fi
+          else
+            if command -v curl >/dev/null 2>&1; then
+              debug ">" curl -fsSL "$url"
+              checksums="$(curl --compressed -fsSL "$url")"
+            else
+              if command -v wget >/dev/null 2>&1; then
+                debug ">" wget -qO - "$url"
+                stderr=$(mktemp)
+                checksums="$(wget -qO - "$url")"
+              else
+                error "mise standalone install specific version requires curl or wget but neither is installed. Aborting."
+              fi
+            fi
+            # TODO: verify with minisign or gpg if available
+
+            checksum="$(echo "$checksums" | grep "$os-$arch.$ext")"
+            if ! echo "$checksum" | grep -Eq "^([0-9a-f]{32}|[0-9a-f]{64})"; then
+              warn "no checksum for mise $version and $os-$arch"
+            else
+              echo "$checksum"
+            fi
+          fi
+        }
+
+        #endregion
+
+        download_file() {
+          url="$1"
+          filename="$(basename "$url")"
+          cache_dir="$(mktemp -d)"
+          file="$cache_dir/$filename"
+
+          info "mise: installing mise..."
+
+          if command -v curl >/dev/null 2>&1; then
+            debug ">" curl -#fLo "$file" "$url"
+            curl -#fLo "$file" "$url"
+          else
+            if command -v wget >/dev/null 2>&1; then
+              debug ">" wget -qO "$file" "$url"
+              stderr=$(mktemp)
+              wget -O "$file" "$url" >"$stderr" 2>&1 || error "wget failed: $(cat "$stderr")"
+            else
+              error "mise standalone install requires curl or wget but neither is installed. Aborting."
+            fi
+          fi
+
+          echo "$file"
+        }
+
+        install_mise() {
+          version="${MISE_VERSION:-v2025.6.4}"
+          version="${version#v}"
+          os="$(get_os)"
+          arch="$(get_arch)"
+          ext="$(get_ext)"
+          install_path="${MISE_INSTALL_PATH:-$HOME/.local/bin/mise}"
+          install_dir="$(dirname "$install_path")"
+          tarball_url="https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-${os}-${arch}.${ext}"
+
+          cache_file=$(download_file "$tarball_url")
+          debug "mise-setup: tarball=$cache_file"
+
+          debug "validating checksum"
+          cd "$(dirname "$cache_file")" && get_checksum "$version" | "$(shasum_bin)" -c >/dev/null
+
+          # extract tarball
+          mkdir -p "$install_dir"
+          rm -rf "$install_path"
+          cd "$(mktemp -d)"
+          if [ "$(get_ext)" = "tar.zst" ] && ! tar_supports_zstd; then
+            zstd -d -c "$cache_file" | tar -xf -
+          else
+            tar -xf "$cache_file"
+          fi
+          mv mise/bin/mise "$install_path"
+          info "mise: installed successfully to $install_path"
+        }
+
+        after_finish_help() {
+          case "${SHELL:-}" in
+          */zsh)
+            info "mise: run the following to activate mise in your shell:"
+            info "echo \"eval \\\"\\\$($install_path activate zsh)\\\"\" >> \"${ZDOTDIR-$HOME}/.zshrc\""
+            info ""
+            info "mise: run \`mise doctor\` to verify this is setup correctly"
+            ;;
+          */bash)
+            info "mise: run the following to activate mise in your shell:"
+            info "echo \"eval \\\"\\\$($install_path activate bash)\\\"\" >> ~/.bashrc"
+            info ""
+            info "mise: run \`mise doctor\` to verify this is setup correctly"
+            ;;
+          */fish)
+            info "mise: run the following to activate mise in your shell:"
+            info "echo \"$install_path activate fish | source\" >> ~/.config/fish/config.fish"
+            info ""
+            info "mise: run \`mise doctor\` to verify this is setup correctly"
+            ;;
+          *)
+            info "mise: run \`$install_path --help\` to get started"
+            ;;
+          esac
+        }
+
+        install_mise
+        if [ "${MISE_INSTALL_HELP-}" != 0 ]; then
+          after_finish_help
+        fi
+
+        cd "$MISE_BOOTSTRAP_PROJECT_DIR"
+    }
+    local MISE_INSTALL_HELP=0
+    test -f "$MISE_INSTALL_PATH" || install
+}
+__mise_bootstrap
+exec "$MISE_INSTALL_PATH" "$@"

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+go = "1.24.3"
+gotestsum = "1.12.2"


### PR DESCRIPTION
What's mise? Tooling version manager, in short. It does provide additional stuff like a task runner, or environment variable management, but let's focus on tooling management.

### Why?

Currently, we use mix of Homebrew and containers (mostly in CI pipeline itself).Results can be... unpredictable. One can happily run tests, pre-commit checks can be all fine, only to see a failed build because $TOOL is in a different version (e.g. pinned container image vs. newest Homebrew package one have installed on their machine).

### How?

With mise.toml committed to a repository (mise is also compatible with asdf `.tool-versions` files as well as [idiomatic version files](https://mise.jdx.dev/configuration.html#idiomatic-version-files) like `.node-version` and `.ruby-version`. See [configuration](https://mise.jdx.dev/configuration.html) for more details.), mise would ensure same tooling is available locally and in CI.

No need to guess what's needed, no hacks to run $TOOL in $VERSION, no fetching a dozen of containers just to run a linter.

https://mise.jdx.dev/continuous-integration.html might be worth exploring, but in my case, I just include eval `"$(mise activate bash)" && mise install` in `pre-command` hook for the agent.

Okay, but how do I use specific version of a tool in my project? 

Locally, start from installing Mise: `brew install mise`. I'd also recommend adding Mise to your shell config, see https://mise.jdx.dev/getting-started.html#activate-mise.

Let's say we want Go 1.23 in our project, but we also have Go 1.24 installed locally, damn!With mise we can pin Go's version in the project by running: `mise use use [go@1.23](mailto:go@1.23)`.Sample output:

```
mise ~/Development/buildkite-agent-scaler/mise.toml tools: go@1.23.9
mise +go@1.23.9
mise -go@1.22.12
```

Boom, we've now pinned Go to the latest version (at the time of running the command) of the 1.23 release!

In fresh projects, we could just execute `mise use go --pin` to use latest version

___
`bin/mise` has been generated with https://mise.jdx.dev/continuous-integration.html#bootstrapping