### PR TITLE
Update to use OIDC session tokens on AWS role assumption in buildkite-dev

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -45,8 +45,12 @@ steps:
     env:
       BUILDKITE_AGENT_GIT_FETCH_FLAGS: -v --prune --tags
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-buildkite-agent-scaler
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
       - aws-ssm#v1.0.0:
           parameters:
             GITHUB_RELEASE_ACCESS_TOKEN: /pipelines/buildkite/buildkite-agent-scaler/GITHUB_RELEASE_ACCESS_TOKEN


### PR DESCRIPTION
### Description

Roll out using session tags for OIDC assumable IAM role trust policy. 
<!--
- What problem are you trying to solve, and how are you solving it?
- What alternatives did you consider?
-->

### Context

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dev/pull/474

<!--
For example, a link to a GitHub issue or a Buildkite internal document such as Linear, Coda, Slack, Basecamp.
-->

### Changes

This is only changing the one pipeline, which uses an IAM role in `buildkite-dev` account. Additional pipelines defined in this repo will be updated when I move on to working on the `ops` repo roles. 
<!--
List of what the PR changes. If the PR changes the CLI arguments, consider adding the output of the various levels of `buildkite-agent <subcomand> --help`.

Can skip if changes are simple or clear from the commit messages.
-->