### PR TITLE
Update to use OIDC session tokens on AWS role assumption

### DIFF
--- a/.buildkite/pipeline-sar.yaml
+++ b/.buildkite/pipeline-sar.yaml
@@ -29,8 +29,12 @@ steps:
       - test
       - build
     plugins:
-      - aws-assume-role-with-web-identity#v1.1.0:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-buildkite-agent-scaler-publish
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
 
   - block: ":package::arrow_right::rocket: Draft :github: Release Approved?"
     key: release
@@ -43,5 +47,9 @@ steps:
     depends_on:
       - release
     plugins:
-      - aws-assume-role-with-web-identity#v1.1.0:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-aws-stack-buildkite-agent-scaler-publish
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -40,8 +40,12 @@ steps:
       - build-lambda
     command: .buildkite/steps/upload-to-s3.sh
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-scaler
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
 
   - if: build.tag =~ /^.+\$/ || build.env("RELEASE_DRY_RUN") == "true"
     label: ":github: Draft GitHub Release"
@@ -81,5 +85,9 @@ steps:
       - block-s3-release
     command: .buildkite/steps/upload-to-s3.sh release
     plugins:
-      - aws-assume-role-with-web-identity:
+      - aws-assume-role-with-web-identity#v1.4.0:
           role-arn: arn:aws:iam::172840064832:role/pipeline-buildkite-buildkite-agent-scaler
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug


### PR DESCRIPTION
Roll out using session tags for OIDC assumable IAM role trust policy.

Follow on from the work to support session tags in https://github.com/buildkite-plugins/aws-assume-role-with-web-identity-buildkite-plugin/pull/18

Requires matching update to the IAM role in PR: https://github.com/buildkite/aws-buildkite-dist/pull/130