### PR TITLE
fix: event schedule examples

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -39,7 +39,7 @@ Parameters:
     Default: ''
 
   EventSchedulePeriod:
-    Description: How often the Event Schedule is triggered. Should be an expression with units, e.g. "30 seconds", "1 minute", "5 minutes".
+    Description: How often the Event Schedule is triggered. Should be an expression with units, e.g. "1 minute", "5 minutes".
     Type: String
     Default: "1 minute"
 


### PR DESCRIPTION
## Changes

- A scaler function event schedule runs on a cron, so having 30 seconds is an invalid option and should be removed from the examples; the minimum value that can be set is `1 minute`, which is already the default
