### PR TITLE
Fix: restore SIGTERM marker

### DIFF
--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -355,7 +355,7 @@ func (a *ASGDriver) SendSIGTERMToAgents(ctx context.Context, instanceID string) 
 		return err
 	}
 
-	// With consecutive Lambda invocations the same instance selected for scale-in, 
+	// With consecutive Lambda invocations the same instance selected for scale-in,
 	// only during the first invocation will actually signal the agent to finish current jobs and stop.
 	command := `#!/bin/bash
 if [ -f /tmp/buildkite-agent-termination-marker ]; then


### PR DESCRIPTION
Addresses https://github.com/buildkite/buildkite-agent-scaler/pull/280#discussion_r2755316070

Fixes missing marker during initial implementation https://github.com/buildkite/buildkite-agent-scaler/pull/212 where `SIGTERM` could be sent twice to the same instance, resulting in stopping agent process immediately, without giving ongoing jobs a chance to finish.