### PR TITLE
Update Lambda runtime to al2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ the following IAM permissions:
 * `autoscaling:DescribeScalingActivities`
 * `autoscaling:SetDesiredCapacity`
 
-Its handler is `bootstrap`, it uses a `provided.al2` runtime and requires the following env vars:
+Its handler is `bootstrap`, it uses a `provided.al2023` runtime and requires the following env vars:
 
 * `BUILDKITE_AGENT_TOKEN` or `BUILDKITE_AGENT_TOKEN_SSM_KEY`
 * `BUILDKITE_QUEUE`
@@ -97,7 +97,7 @@ aws lambda create-function \
   --function-name buildkite-agent-scaler \
   --memory 128 \
   --role arn:aws:iam::account-id:role/execution_role \
-  --runtime provided.al2 \
+  --runtime provided.al2023 \
   --zip-file fileb://handler.zip \
   --handler bootstrap
 ```

--- a/template.yaml
+++ b/template.yaml
@@ -301,7 +301,7 @@ Resources:
       PermissionsBoundary: !If [ SetRolePermissionsBoundaryARN, !Ref RolePermissionsBoundaryARN, !Ref "AWS::NoValue" ]
       Timeout: 120
       Handler: bootstrap
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Architectures:
         - x86_64
       MemorySize: 128


### PR DESCRIPTION
`provided.al2` is reaching End of Life, 30 June 2026. Updating to `provided.al2023` runtime with EoL in Jun 30, 2029.

Fixes #287