### PR TITLE
chore: remove support from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @buildkite/support
 * @buildkite/agent-stewards


### PR DESCRIPTION
## Description

Support being in the CODEOWNERS file is left over from when they briefly owned the stack and causes confusion on issues/PRs
