### PR TITLE
Bump Go to 1.26.1, and gotestsum to 1.13.0

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-go = "1.25.1"
-gotestsum = "1.12.2"
+go = "1.26.1"
+gotestsum = "1.13.0"


### PR DESCRIPTION
Addresses https://pkg.go.dev/vuln/GO-2026-4337