### PR TITLE
Handle stale instance IDs in DescribeInstances batch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.294.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.2
+	github.com/aws/smithy-go v1.24.2
 )
 
 require (
@@ -24,5 +25,4 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.8 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
 )

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -451,9 +451,7 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 		return nil
 	}
 
-	descInstancesOutput, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-		InstanceIds: asgDetails.InstanceIDs,
-	})
+	descInstancesOutput, err := describeInstancesTolerant(ctx, ec2Client, asgDetails.InstanceIDs, a.Name)
 	if err != nil {
 		return fmt.Errorf("failed to describe instances in ASG %s: %w", a.Name, err)
 	}

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/aws/smithy-go"
 )
 
 // ErrWindowsGracefulScaleInNotSupported is returned when attempting graceful scale-in on Windows instances.
@@ -517,6 +519,50 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 	}
 
 	return firstErrorEncountered
+}
+
+// describeInstancesAPI is the subset of ec2.Client used by describeInstancesTolerant.
+// Defined as an interface so tests can substitute a stub without wiring a full EC2 mock.
+type describeInstancesAPI interface {
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}
+
+// describeInstancesTolerant calls EC2 DescribeInstances and retries once with stale IDs
+// removed if the API returns InvalidInstanceID.NotFound. This handles the race where an
+// instance is terminated between the ASG Describe and the EC2 Describe. If all IDs are
+// stale, an empty output is returned.
+func describeInstancesTolerant(ctx context.Context, client describeInstancesAPI, instanceIDs []string, asgName string) (*ec2.DescribeInstancesOutput, error) {
+	out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: instanceIDs})
+	if err == nil {
+		return out, nil
+	}
+
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) || apiErr.ErrorCode() != "InvalidInstanceID.NotFound" {
+		return nil, err
+	}
+
+	stale := parseStaleInstanceIDs(apiErr.ErrorMessage())
+	if len(stale) == 0 {
+		return nil, err
+	}
+
+	staleSet := make(map[string]struct{}, len(stale))
+	for _, id := range stale {
+		staleSet[id] = struct{}{}
+	}
+	remaining := slices.DeleteFunc(slices.Clone(instanceIDs), func(id string) bool {
+		_, ok := staleSet[id]
+		return ok
+	})
+	log.Printf("[Elastic CI Mode] Skipping %d stale instance ID(s) in ASG %s (no longer present in EC2): %v", len(stale), asgName, stale)
+
+	if len(remaining) == 0 {
+		log.Printf("[Elastic CI Mode] All %d instance ID(s) in ASG %s are stale; nothing to check", len(instanceIDs), asgName)
+		return &ec2.DescribeInstancesOutput{}, nil
+	}
+
+	return client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: remaining})
 }
 
 var staleInstanceIDRegex = regexp.MustCompile(`i-[0-9a-f]{8,17}`)

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -516,6 +517,14 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 	}
 
 	return firstErrorEncountered
+}
+
+var staleInstanceIDRegex = regexp.MustCompile(`i-[0-9a-f]{8,17}`)
+
+// parseStaleInstanceIDs extracts instance IDs from an InvalidInstanceID.NotFound message.
+// Example: "The instance IDs 'i-0abc1234def5, i-0def5678abcd' do not exist"
+func parseStaleInstanceIDs(msg string) []string {
+	return staleInstanceIDRegex.FindAllString(msg, -1)
 }
 
 func (a *dryRunASG) Describe(ctx context.Context) (AutoscaleGroupDetails, error) {

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -2,12 +2,15 @@ package scaler
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/smithy-go"
 )
 
 func TestGetASGPlatform(t *testing.T) {
@@ -109,6 +112,139 @@ func TestParseStaleInstanceIDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+type stubDescribeInstancesClient struct {
+	calls []ec2.DescribeInstancesInput
+	// responses[i] is returned on the i-th call; defaults to (empty output, nil) if exhausted.
+	responses []stubDescribeResponse
+}
+
+type stubDescribeResponse struct {
+	out *ec2.DescribeInstancesOutput
+	err error
+}
+
+func (s *stubDescribeInstancesClient) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	s.calls = append(s.calls, *params)
+	idx := len(s.calls) - 1
+	if idx >= len(s.responses) {
+		return &ec2.DescribeInstancesOutput{}, nil
+	}
+	r := s.responses[idx]
+	return r.out, r.err
+}
+
+func TestDescribeInstancesTolerant(t *testing.T) {
+	ctx := context.Background()
+	staleErr := &smithy.GenericAPIError{
+		Code:    "InvalidInstanceID.NotFound",
+		Message: "The instance IDs 'i-0abc1234, i-0def5678' do not exist",
+	}
+
+	t.Run("success on first call returns output unchanged", func(t *testing.T) {
+		expected := &ec2.DescribeInstancesOutput{Reservations: []ec2Types.Reservation{{}}}
+		stub := &stubDescribeInstancesClient{
+			responses: []stubDescribeResponse{{out: expected, err: nil}},
+		}
+		out, err := describeInstancesTolerant(ctx, stub, []string{"i-a", "i-b"}, "asg-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != expected {
+			t.Errorf("expected output to be passed through unchanged")
+		}
+		if len(stub.calls) != 1 {
+			t.Errorf("expected 1 call, got %d", len(stub.calls))
+		}
+	})
+
+	t.Run("stale IDs removed and retry succeeds", func(t *testing.T) {
+		retryOut := &ec2.DescribeInstancesOutput{Reservations: []ec2Types.Reservation{{}}}
+		stub := &stubDescribeInstancesClient{
+			responses: []stubDescribeResponse{
+				{out: nil, err: staleErr},
+				{out: retryOut, err: nil},
+			},
+		}
+		out, err := describeInstancesTolerant(ctx, stub, []string{"i-0abc1234", "i-0def5678", "i-0999aabb"}, "asg-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out != retryOut {
+			t.Errorf("expected retry output to be returned")
+		}
+		if len(stub.calls) != 2 {
+			t.Fatalf("expected 2 calls (original + retry), got %d", len(stub.calls))
+		}
+		if !slices.Equal(stub.calls[1].InstanceIds, []string{"i-0999aabb"}) {
+			t.Errorf("retry InstanceIds = %v, want [i-0999aabb]", stub.calls[1].InstanceIds)
+		}
+	})
+
+	t.Run("all IDs stale returns empty output without retry", func(t *testing.T) {
+		stub := &stubDescribeInstancesClient{
+			responses: []stubDescribeResponse{{out: nil, err: staleErr}},
+		}
+		out, err := describeInstancesTolerant(ctx, stub, []string{"i-0abc1234", "i-0def5678"}, "asg-1")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if out == nil || len(out.Reservations) != 0 {
+			t.Errorf("expected empty output, got %+v", out)
+		}
+		if len(stub.calls) != 1 {
+			t.Errorf("expected 1 call (no retry when all stale), got %d", len(stub.calls))
+		}
+	})
+
+	t.Run("non-stale error returned as-is", func(t *testing.T) {
+		otherErr := &smithy.GenericAPIError{Code: "UnauthorizedOperation", Message: "denied"}
+		stub := &stubDescribeInstancesClient{
+			responses: []stubDescribeResponse{{out: nil, err: otherErr}},
+		}
+		_, err := describeInstancesTolerant(ctx, stub, []string{"i-a"}, "asg-1")
+		if !errors.Is(err, otherErr) {
+			t.Errorf("expected pass-through of UnauthorizedOperation, got %v", err)
+		}
+		if len(stub.calls) != 1 {
+			t.Errorf("expected no retry for non-stale error, got %d calls", len(stub.calls))
+		}
+	})
+
+	t.Run("second NotFound on retry is not retried again", func(t *testing.T) {
+		secondStaleErr := &smithy.GenericAPIError{
+			Code:    "InvalidInstanceID.NotFound",
+			Message: "The instance ID 'i-0999aabb00' does not exist",
+		}
+		stub := &stubDescribeInstancesClient{
+			responses: []stubDescribeResponse{
+				{out: nil, err: staleErr},
+				{out: nil, err: secondStaleErr},
+			},
+		}
+		_, err := describeInstancesTolerant(ctx, stub, []string{"i-0abc1234", "i-0def5678", "i-0999aabb00"}, "asg-1")
+		if !errors.Is(err, secondStaleErr) {
+			t.Errorf("expected second NotFound to propagate, got %v", err)
+		}
+		if len(stub.calls) != 2 {
+			t.Errorf("expected exactly 2 calls (no second retry), got %d", len(stub.calls))
+		}
+	})
+
+	t.Run("stale error with no parseable IDs returned as-is", func(t *testing.T) {
+		malformed := &smithy.GenericAPIError{
+			Code:    "InvalidInstanceID.NotFound",
+			Message: "something went wrong but no IDs are in this message",
+		}
+		stub := &stubDescribeInstancesClient{
+			responses: []stubDescribeResponse{{out: nil, err: malformed}},
+		}
+		_, err := describeInstancesTolerant(ctx, stub, []string{"i-a"}, "asg-1")
+		if !errors.Is(err, malformed) {
+			t.Errorf("expected pass-through when no IDs parseable, got %v", err)
+		}
+	})
 }
 
 func TestGetCheckCommand(t *testing.T) {

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -2,6 +2,7 @@ package scaler
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -67,6 +68,44 @@ func TestGetASGPlatform(t *testing.T) {
 			platform := driver.getASGPlatform(ctx, tc.instances)
 			if platform != tc.expectedPlatform {
 				t.Errorf("expected platform %q, got %q", tc.expectedPlatform, platform)
+			}
+		})
+	}
+}
+
+func TestParseStaleInstanceIDs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		msg      string
+		expected []string
+	}{
+		{
+			name:     "single stale ID",
+			msg:      "The instance ID 'i-0027f3b5de8a270d2' does not exist",
+			expected: []string{"i-0027f3b5de8a270d2"},
+		},
+		{
+			name:     "multiple stale IDs",
+			msg:      "The instance IDs 'i-0abc1234, i-0def5678, i-0099aabbccdd' do not exist",
+			expected: []string{"i-0abc1234", "i-0def5678", "i-0099aabbccdd"},
+		},
+		{
+			name:     "message with no instance IDs",
+			msg:      "You are not authorized to perform this operation",
+			expected: nil,
+		},
+		{
+			name:     "empty message",
+			msg:      "",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseStaleInstanceIDs(tc.msg)
+			if !slices.Equal(got, tc.expected) {
+				t.Errorf("parseStaleInstanceIDs(%q) = %v, want %v", tc.msg, got, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
### Problem

`CleanupDanglingInstances` puts every ASG InstanceID into one `ec2:DescribeInstances` call. 
If any one of them has terminated between the ASG Describe and the EC2 Describe, AWS returns `InvalidInstanceID.NotFound` and the whole batch fails.

### Fix
New `describeInstancesTolerant` helper wraps the call. On `InvalidInstanceID.NotFound` (detected via `smithy.APIError`), it pulls the stale IDs out of the message, drops them, retries once. 
If everything was stale, it returns an empty output and the cleanup loop does nothing. Any other error, or a second `NotFound` on the retry, is returned as-is – one retry, no loops.