### PR TITLE
Use adaptive AWS retryer

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 	"github.com/buildkite/buildkite-agent-scaler/scaler"
 	"github.com/buildkite/buildkite-agent-scaler/version"
@@ -96,7 +95,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	}
 
 	// establish an AWS session to be re-used
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := scaler.LoadAWSConfig(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 	"github.com/buildkite/buildkite-agent-scaler/scaler"
 )
@@ -42,7 +41,7 @@ func main() {
 
 	// establish an AWS session to be re-used
 	ctx := context.Background()
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := scaler.LoadAWSConfig(ctx)
 	if err != nil {
 		log.Fatal("unable to load SDK config, ", err)
 	}

--- a/scaler/aws_config.go
+++ b/scaler/aws_config.go
@@ -1,0 +1,27 @@
+package scaler
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+// LoadAWSConfig loads the AWS SDK config with adaptive retry mode and 8 max
+// attempts. The SDK default (3 attempts, no client-side rate limiting) gives
+// up on throttling errors when many scaler Lambdas hit the same APIs at once.
+//
+// Set AWS_RETRY_MODE or AWS_MAX_ATTEMPTS to override.
+func LoadAWSConfig(ctx context.Context) (aws.Config, error) {
+	var opts []func(*config.LoadOptions) error
+
+	if os.Getenv("AWS_RETRY_MODE") == "" {
+		opts = append(opts, config.WithRetryMode(aws.RetryModeAdaptive))
+	}
+	if os.Getenv("AWS_MAX_ATTEMPTS") == "" {
+		opts = append(opts, config.WithRetryMaxAttempts(8))
+	}
+
+	return config.LoadDefaultConfig(ctx, opts...)
+}

--- a/scaler/aws_config_test.go
+++ b/scaler/aws_config_test.go
@@ -1,0 +1,45 @@
+package scaler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestLoadAWSConfigUsesAdaptiveRetryer(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	// Clear env-var overrides so the test observes the code-level defaults.
+	t.Setenv("AWS_RETRY_MODE", "")
+	t.Setenv("AWS_MAX_ATTEMPTS", "")
+
+	cfg, err := LoadAWSConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadAWSConfig returned error: %v", err)
+	}
+
+	if cfg.RetryMode != aws.RetryModeAdaptive {
+		t.Errorf("cfg.RetryMode = %q, want %q", cfg.RetryMode, aws.RetryModeAdaptive)
+	}
+	if cfg.RetryMaxAttempts != 8 {
+		t.Errorf("cfg.RetryMaxAttempts = %d, want 8", cfg.RetryMaxAttempts)
+	}
+}
+
+func TestLoadAWSConfigHonorsEnvOverrides(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_RETRY_MODE", "standard")
+	t.Setenv("AWS_MAX_ATTEMPTS", "3")
+
+	cfg, err := LoadAWSConfig(context.Background())
+	if err != nil {
+		t.Fatalf("LoadAWSConfig returned error: %v", err)
+	}
+
+	if cfg.RetryMode != aws.RetryModeStandard {
+		t.Errorf("env override AWS_RETRY_MODE=standard ignored: cfg.RetryMode = %q", cfg.RetryMode)
+	}
+	if cfg.RetryMaxAttempts != 3 {
+		t.Errorf("env override AWS_MAX_ATTEMPTS=3 ignored: cfg.RetryMaxAttempts = %d", cfg.RetryMaxAttempts)
+	}
+}


### PR DESCRIPTION
The SDK default (standard, 3 attempts, no client-side rate limiting) lets throttling errors through when many scaler Lambdas hit the same AWS APIs at once. Adaptive mode adds a token bucket that backs off when AWS throttles.

New `scaler.LoadAWSConfig` wraps `config.LoadDefaultConfig` for the CLI and Lambda entry points and skips its defaults if `AWS_RETRY_MODE` or `AWS_MAX_ATTEMPTS` is set.

Refs SUP-6910, SUP-6908.