### PR TITLE
Add scheduled scaler invocation jitter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ handler-arm64.zip: bootstrap-arm64
 	@zip -9 -v -j $@ bootstrap
 	@rm -f bootstrap
 
-bootstrap: lambda/main.go
+bootstrap: lambda/*.go
 	GOARCH=amd64 mise exec -- go build \
 	    -ldflags="$(LD_FLAGS)" \
 	    -buildvcs="$(BUILDVCS_FLAG)" \
@@ -40,7 +40,7 @@ bootstrap: lambda/main.go
 	    -o bootstrap \
 	    ./lambda
 
-bootstrap-arm64: lambda/main.go
+bootstrap-arm64: lambda/*.go
 	GOARCH=arm64 mise exec -- go build \
 	    -ldflags="$(LD_FLAGS)" \
 	    -buildvcs="$(BUILDVCS_FLAG)" \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Set `AVAILABILITY_THRESHOLD=0` to disable availability-based scaling. The scaler
 * **Higher threshold (e.g., 0.8)**: Aggressive scaling to maintain high availability when agents are expected to connect quickly
 * **Disabled (0)**: Job-based scaling only, suitable when agents connect reliably
 
+### Scheduled invocation jitter
+
+When many scaler Lambdas run on the same schedule in one AWS account, they can all poll AWS APIs at
+the same time. Set `EventScheduleJitter` in the Serverless Application template, or
+`LAMBDA_STARTUP_JITTER_MAX` directly on the Lambda, to spread scheduled invocations across a
+deterministic delay window. For example, `30s` gives each Auto Scaling group a stable delay from 0
+to 30 seconds before polling APIs.
+
 ## Gracefully scaling in
 
 :construction: For [Elastic CI Stack][], there's now available a dedicated and experimental mode configured with `ELASTIC_CI_MODE` variable. You can read more about it [in here](./docs/elastic_ci_mode.md). :construction:

--- a/lambda/jitter.go
+++ b/lambda/jitter.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"hash/fnv"
+	"log"
+	"time"
+)
+
+func deterministicJitter(key string, max time.Duration) time.Duration {
+	if key == "" || max <= 0 {
+		return 0
+	}
+
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+
+	return time.Duration(h.Sum64() % uint64(max))
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func applyStartupJitter(ctx context.Context, key string, max time.Duration) error {
+	jitter := deterministicJitter(key, max)
+	if jitter <= 0 {
+		return nil
+	}
+
+	log.Printf("Waiting %v before polling to stagger scheduled scaler invocations", jitter)
+	return sleepWithContext(ctx, jitter)
+}

--- a/lambda/jitter_test.go
+++ b/lambda/jitter_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDeterministicJitter(t *testing.T) {
+	max := 30 * time.Second
+
+	got := deterministicJitter("stack-a-AgentAutoScaleGroup", max)
+	if got <= 0 {
+		t.Fatalf("deterministicJitter() = %v, want positive duration", got)
+	}
+	if got >= max {
+		t.Fatalf("deterministicJitter() = %v, want less than %v", got, max)
+	}
+
+	again := deterministicJitter("stack-a-AgentAutoScaleGroup", max)
+	if got != again {
+		t.Fatalf("deterministicJitter() = %v then %v, want stable result", got, again)
+	}
+}
+
+func TestDeterministicJitterDisabled(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+		max  time.Duration
+	}{
+		{name: "empty key", key: "", max: 30 * time.Second},
+		{name: "zero max", key: "stack-a-AgentAutoScaleGroup", max: 0},
+		{name: "negative max", key: "stack-a-AgentAutoScaleGroup", max: -1 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deterministicJitter(tc.key, tc.max); got != 0 {
+				t.Fatalf("deterministicJitter() = %v, want 0", got)
+			}
+		})
+	}
+}
+
+func TestSleepWithContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sleepWithContext(ctx, time.Minute)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("sleepWithContext() error = %v, want context.Canceled", err)
+	}
+}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -47,8 +47,14 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	agentsPerInstance := RequireEnvInt("AGENTS_PER_INSTANCE")
 
 	// Optional environment variables (but they must parse correctly if set).
+	startupJitterMax := EnvDuration("LAMBDA_STARTUP_JITTER_MAX", 0)
 	interval := EnvDuration("LAMBDA_INTERVAL", 10*time.Second)
 	timeoutDuration := EnvDuration("LAMBDA_TIMEOUT", -1)
+
+	if err := applyStartupJitter(ctx, asgName, startupJitterMax); err != nil {
+		return "", err
+	}
+
 	var timeout <-chan time.Time
 	if timeoutDuration >= 0 {
 		timeout = time.After(timeoutDuration)

--- a/template.yaml
+++ b/template.yaml
@@ -43,6 +43,11 @@ Parameters:
     Type: String
     Default: "1 minute"
 
+  EventScheduleJitter:
+    Description: Maximum deterministic delay before scheduled scaler invocations poll APIs. Use this to stagger many scaler Lambdas, e.g. "30s".
+    Type: String
+    Default: "0s"
+
   AgentsPerInstance:
     Description: ""
     Type: Number
@@ -326,6 +331,7 @@ Resources:
           INCLUDE_WAITING:               !Ref ScaleOutForWaitingJobs
           LAMBDA_TIMEOUT:                "50s"
           LAMBDA_INTERVAL:               !Ref MinPollInterval
+          LAMBDA_STARTUP_JITTER_MAX:     !Ref EventScheduleJitter
           MAX_DESCRIBE_SCALING_ACTIVITIES_PAGES: !Ref MaxDescribeScalingActivitiesPages
           AVAILABILITY_THRESHOLD:        !Ref AvailabilityThreshold
           SCALE_IN_COOLDOWN_PERIOD:      !Sub "${ScaleInCooldownPeriod}s"


### PR DESCRIPTION
## Summary
- Add a deterministic startup jitter window for scheduled scaler Lambda invocations.
- Expose the setting through the Serverless Application template as `EventScheduleJitter`, defaulting to `0s`.
- Update Lambda build dependencies so helper changes rebuild both architecture bundles.

## Test plan
- `MISE_TRUSTED_CONFIG_PATHS=/Users/vivek/Code/buildkite-agent-scaler/mise.toml mise exec -- go test ./...`
- `MISE_TRUSTED_CONFIG_PATHS=/Users/vivek/Code/buildkite-agent-scaler/mise.toml make build && make clean`
- `git diff --check`


Made with [Cursor](https://cursor.com)