### PR TITLE
Improve error message for 401 Unauthorized from Buildkite metrics API

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -15,19 +15,29 @@ import (
 
 const (
 	PollDurationHeader = "Buildkite-Agent-Metrics-Poll-Duration"
+
+	// defaultAgentTokenSource is used in error messages when the caller
+	// hasn't set AgentTokenSource to describe where the token came from.
+	defaultAgentTokenSource = "configured source"
 )
 
 type Client struct {
 	Endpoint   string
 	AgentToken string
-	UserAgent  string
+	// AgentTokenSource describes where AgentToken was retrieved from, e.g.
+	// "BUILDKITE_AGENT_TOKEN environment variable" or `SSM parameter
+	// "/my/param"`. It's used to give a more actionable error message if
+	// the token is rejected by the Buildkite Agent Metrics API.
+	AgentTokenSource string
+	UserAgent        string
 }
 
 func NewClient(agentToken, agentEndpoint string) *Client {
 	return &Client{
-		Endpoint:   agentEndpoint,
-		UserAgent:  fmt.Sprintf("buildkite-agent-scaler/%s", version.VersionString()),
-		AgentToken: agentToken,
+		Endpoint:         agentEndpoint,
+		UserAgent:        fmt.Sprintf("buildkite-agent-scaler/%s", version.VersionString()),
+		AgentToken:       agentToken,
+		AgentTokenSource: defaultAgentTokenSource,
 	}
 }
 
@@ -115,6 +125,15 @@ func (c *Client) queryMetrics(ctx context.Context, into interface{}, queue strin
 		return time.Duration(0), err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == http.StatusUnauthorized {
+		return time.Duration(0), fmt.Errorf(
+			"couldn't retrieve Buildkite metrics for the `%s` queue: "+
+				"the Buildkite Agent token retrieved from the %s was rejected (%s). "+
+				"Retrieve or generate a new Buildkite Agent token from https://buildkite.com/organizations/-/agents "+
+				"and update the %s with the new value",
+			queue, c.AgentTokenSource, res.Status, c.AgentTokenSource,
+		)
+	}
 	if res.StatusCode != http.StatusOK {
 		return time.Duration(0), fmt.Errorf("%s %s: %s", req.Method, endpoint, res.Status)
 	}

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/buildkite/buildkite-agent-scaler/version"
@@ -127,11 +129,11 @@ func (c *Client) queryMetrics(ctx context.Context, into interface{}, queue strin
 	defer res.Body.Close()
 	if res.StatusCode == http.StatusUnauthorized {
 		return time.Duration(0), fmt.Errorf(
-			"couldn't retrieve Buildkite metrics for the `%s` queue: "+
+			"couldn't retrieve Buildkite metrics for the `%s` queue from %s: "+
 				"the Buildkite Agent token retrieved from the %s was rejected (%s). "+
 				"Retrieve or generate a new Buildkite Agent token from https://buildkite.com/organizations/-/agents "+
 				"and update the %s with the new value",
-			queue, c.AgentTokenSource, res.Status, c.AgentTokenSource,
+			queue, endpoint, c.AgentTokenSource, responseErrorDetail(res), c.AgentTokenSource,
 		)
 	}
 	if res.StatusCode != http.StatusOK {
@@ -149,4 +151,27 @@ func (c *Client) queryMetrics(ctx context.Context, into interface{}, queue strin
 	}
 
 	return pollDuration, json.NewDecoder(res.Body).Decode(into)
+}
+
+// responseErrorDetail reads res.Body and folds it into a human-readable
+// status string, e.g. `401 Unauthorized: Eeep! You forgot to pass an agent
+// registration token`. Callers should not read res.Body afterwards.
+func responseErrorDetail(res *http.Response) string {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return res.Status
+	}
+
+	var parsed struct {
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Message != "" {
+		return fmt.Sprintf("%s: %s", res.Status, parsed.Message)
+	}
+
+	if trimmed := strings.TrimSpace(string(body)); trimmed != "" {
+		return fmt.Sprintf("%s: %s", res.Status, trimmed)
+	}
+
+	return res.Status
 }

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -32,10 +33,52 @@ func TestUnauthorizedResponse(t *testing.T) {
 	}))
 	c := NewClient("testtoken", "https://agent.buildkite.com/v3")
 	c.Endpoint = s.URL
+	c.AgentTokenSource = `SSM parameter "/my/param" (BUILDKITE_AGENT_TOKEN_SSM_KEY)`
 	_, err := c.GetAgentMetrics(context.Background(), "default")
-	if err != nil {
-		t.Log("(expected error)", err)
-	} else {
-		t.Error("expected error representing non-200 HTTP status")
+	if err == nil {
+		t.Fatal("expected error representing non-200 HTTP status")
+	}
+	t.Log("(expected error)", err)
+
+	// The error should read like a title, a description of what went
+	// wrong (naming where the rejected token came from), and a recovery
+	// suggestion pointing the user at how to fix it.
+	wantParts := []string{
+		"couldn't retrieve Buildkite metrics for the `default` queue",
+		`the Buildkite Agent token retrieved from the SSM parameter "/my/param" (BUILDKITE_AGENT_TOKEN_SSM_KEY) was rejected`,
+		"https://buildkite.com/organizations/-/agents",
+		`update the SSM parameter "/my/param" (BUILDKITE_AGENT_TOKEN_SSM_KEY) with the new value`,
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing expected part %q, got: %s", want, err.Error())
+		}
+	}
+}
+
+func TestUnauthorizedResponseWithEnvVarTokenSource(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		io.WriteString(w, `{"message": "Eeep! You forgot to pass an agent registration token"}`)
+	}))
+	c := NewClient("testtoken", "https://agent.buildkite.com/v3")
+	c.Endpoint = s.URL
+	c.AgentTokenSource = "BUILDKITE_AGENT_TOKEN environment variable"
+	_, err := c.GetAgentMetrics(context.Background(), "default")
+	if err == nil {
+		t.Fatal("expected error representing non-200 HTTP status")
+	}
+	t.Log("(expected error)", err)
+
+	wantParts := []string{
+		"couldn't retrieve Buildkite metrics for the `default` queue",
+		"the Buildkite Agent token retrieved from the BUILDKITE_AGENT_TOKEN environment variable was rejected",
+		"https://buildkite.com/organizations/-/agents",
+		"update the BUILDKITE_AGENT_TOKEN environment variable with the new value",
+	}
+	for _, want := range wantParts {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing expected part %q, got: %s", want, err.Error())
+		}
 	}
 }

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -33,7 +33,7 @@ func TestUnauthorizedResponse(t *testing.T) {
 	}))
 	c := NewClient("testtoken", "https://agent.buildkite.com/v3")
 	c.Endpoint = s.URL
-	c.AgentTokenSource = `SSM parameter "/my/param" (BUILDKITE_AGENT_TOKEN_SSM_KEY)`
+	c.AgentTokenSource = `SSM parameter "/my/param"`
 	_, err := c.GetAgentMetrics(context.Background(), "default")
 	if err == nil {
 		t.Fatal("expected error representing non-200 HTTP status")
@@ -41,13 +41,16 @@ func TestUnauthorizedResponse(t *testing.T) {
 	t.Log("(expected error)", err)
 
 	// The error should read like a title, a description of what went
-	// wrong (naming where the rejected token came from), and a recovery
-	// suggestion pointing the user at how to fix it.
+	// wrong (naming the endpoint hit, where the rejected token came from,
+	// and the API's own response body), and a recovery suggestion
+	// pointing the user at how to fix it.
 	wantParts := []string{
 		"couldn't retrieve Buildkite metrics for the `default` queue",
-		`the Buildkite Agent token retrieved from the SSM parameter "/my/param" (BUILDKITE_AGENT_TOKEN_SSM_KEY) was rejected`,
+		"from " + s.URL,
+		`the Buildkite Agent token retrieved from the SSM parameter "/my/param" was rejected`,
+		"Eeep! You forgot to pass an agent registration token",
 		"https://buildkite.com/organizations/-/agents",
-		`update the SSM parameter "/my/param" (BUILDKITE_AGENT_TOKEN_SSM_KEY) with the new value`,
+		`update the SSM parameter "/my/param" with the new value`,
 	}
 	for _, want := range wantParts {
 		if !strings.Contains(err.Error(), want) {
@@ -72,7 +75,9 @@ func TestUnauthorizedResponseWithEnvVarTokenSource(t *testing.T) {
 
 	wantParts := []string{
 		"couldn't retrieve Buildkite metrics for the `default` queue",
+		"from " + s.URL,
 		"the Buildkite Agent token retrieved from the BUILDKITE_AGENT_TOKEN environment variable was rejected",
+		"Eeep! You forgot to pass an agent registration token",
 		"https://buildkite.com/organizations/-/agents",
 		"update the BUILDKITE_AGENT_TOKEN environment variable with the new value",
 	}

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"math"
 	"os"
@@ -158,12 +159,14 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	token := os.Getenv("BUILDKITE_AGENT_TOKEN")
 	ssmTokenKey := os.Getenv("BUILDKITE_AGENT_TOKEN_SSM_KEY")
 
+	agentTokenSource := "BUILDKITE_AGENT_TOKEN environment variable"
 	if ssmTokenKey != "" {
 		tk, err := scaler.RetrieveFromParameterStore(cfg, ssmTokenKey)
 		if err != nil {
 			return "", err
 		}
 		token = tk
+		agentTokenSource = fmt.Sprintf("SSM parameter %q (BUILDKITE_AGENT_TOKEN_SSM_KEY)", ssmTokenKey)
 	}
 
 	if token == "" {
@@ -171,6 +174,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 	}
 
 	client := buildkite.NewClient(token, buildkiteAgentEndpoint)
+	client.AgentTokenSource = agentTokenSource
 
 	params := scaler.Params{
 		BuildkiteQueue:       buildkiteQueue,

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -166,7 +166,7 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			return "", err
 		}
 		token = tk
-		agentTokenSource = fmt.Sprintf("SSM parameter %q (BUILDKITE_AGENT_TOKEN_SSM_KEY)", ssmTokenKey)
+		agentTokenSource = fmt.Sprintf("SSM parameter %q", ssmTokenKey)
 	}
 
 	if token == "" {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"time"
 
@@ -48,15 +49,18 @@ func main() {
 		log.Fatal("unable to load SDK config, ", err)
 	}
 
+	agentTokenSource := "-agent-token flag"
 	if *ssmTokenKey != "" {
 		token, err := scaler.RetrieveFromParameterStore(cfg, *ssmTokenKey)
 		if err != nil {
 			log.Fatal(err)
 		}
 		buildkiteAgentToken = &token
+		agentTokenSource = fmt.Sprintf("SSM parameter %q (-agent-token-ssm-key)", *ssmTokenKey)
 	}
 
 	client := buildkite.NewClient(*buildkiteAgentToken, *buildkiteAgentEndpoint)
+	client.AgentTokenSource = agentTokenSource
 
 	scaler, err := scaler.NewScaler(client, cfg, scaler.Params{
 		BuildkiteQueue:           *buildkiteQueue,


### PR DESCRIPTION
## What

Fixes #58. When the Buildkite Agent Metrics API rejects the agent token (HTTP 401), the error message now includes:

- **Title**: what the scaler was attempting to do (e.g. `couldn't retrieve Buildkite metrics for the `queue` queue`)
- **Description**: that the token was rejected, naming exactly where it was retrieved from (env var, SSM parameter, or CLI flag) based on the actual runtime configuration
- **Recovery suggestion**: a pointer to https://buildkite.com/organizations/-/agents and instructions to update the same source

Previously it just logged a generic `GET <url>: 401 Unauthorized`, which several users found confusing (see comments on #58).

## How

- Added an `AgentTokenSource` field to `buildkite.Client`, set by both the CLI (`main.go`) and the Lambda handler (`lambda/main.go`) to describe where the token came from at runtime.
- Added a dedicated `http.StatusUnauthorized` branch in `queryMetrics` that builds the three-part message using that field. Non-401 non-200 responses keep their original generic error (unchanged).
- Added test coverage for both the SSM-parameter and environment-variable token sources.

## Testing

```
go build ./...   # pass
go vet ./...      # pass
gofmt -l ./        # clean
go test ./...     # all packages pass
```