### PR TITLE
Handle draining agents during dangling cleanup

### DIFF
--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -116,16 +116,29 @@ if ($AgentStatus -match "SERVICE_RUNNING") {
 	// Default to Linux
 	return `#!/bin/bash
 # Linux check command
-if [ -f /tmp/buildkite-agent-termination-marker ]; then
-  echo "MARKER_EXISTS: Instance is already marked for termination"
+if ! SERVICE_STATE=$(systemctl show buildkite-agent --property=ActiveState --property=MainPID 2>&1); then
+  echo "UNKNOWN: $SERVICE_STATE"
   exit 0
 fi
 
-ACTIVE_STATE=$(systemctl show buildkite-agent -p ActiveState | cut -d= -f2)
-case "$ACTIVE_STATE" in
-  "active"|"activating") echo "RUNNING" ;;
-  *) echo "NOT_RUNNING: $ACTIVE_STATE" ;;
+ACTIVE_STATE=$(printf '%s\n' "$SERVICE_STATE" | sed -n 's/^ActiveState=//p')
+MAIN_PID=$(printf '%s\n' "$SERVICE_STATE" | sed -n 's/^MainPID=//p')
+case "$ACTIVE_STATE:$MAIN_PID" in
+  :*|*:|*:*[!0-9]*)
+    echo "UNKNOWN: ActiveState=$ACTIVE_STATE MainPID=$MAIN_PID"
+    exit 0
+    ;;
 esac
+
+if [ "$MAIN_PID" != "0" ] || [ "$ACTIVE_STATE" = "activating" ]; then
+  if [ -f /tmp/buildkite-agent-termination-marker ]; then
+    echo "DRAINING: ActiveState=$ACTIVE_STATE MainPID=$MAIN_PID"
+  else
+    echo "RUNNING"
+  fi
+else
+  echo "NOT_RUNNING: ActiveState=$ACTIVE_STATE"
+fi
 `
 }
 
@@ -255,20 +268,20 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 	ssmSvc ssmCheckAPI,
 	asgSvc asgHealthAPI,
 	platform string,
-) (markedUnhealthyCount int, checkedCount int, firstError error) {
+) (markedUnhealthyCount int, checkedCount int, drainingCount int, firstError error) {
 	if len(instances) == 0 {
-		return 0, 0, nil
+		return 0, 0, 0, nil
 	}
 
 	onlineIDs, err := filterOnlineSSMInstances(ctx, ssmSvc, instances)
 	if err != nil {
-		return 0, 0, fmt.Errorf("DescribeInstanceInformation failed: %w", err)
+		return 0, 0, 0, fmt.Errorf("DescribeInstanceInformation failed: %w", err)
 	}
 	if offline := len(instances) - len(onlineIDs); offline > 0 {
 		log.Printf("[Elastic CI Mode] SSM agent not online for %d of %d instance(s); skipping those", offline, len(instances))
 	}
 	if len(onlineIDs) == 0 {
-		return 0, 0, nil
+		return 0, 0, 0, nil
 	}
 
 	documentName := "AWS-RunShellScript"
@@ -288,7 +301,7 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 			Comment:      aws.String("Check if buildkite-agent service is running"),
 		})
 		if err != nil {
-			return 0, 0, fmt.Errorf("SendCommand failed: %w", err)
+			return 0, 0, 0, fmt.Errorf("SendCommand failed: %w", err)
 		}
 		commandIDs = append(commandIDs, *sendOut.Command.CommandId)
 	}
@@ -307,10 +320,10 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 		firstError = fmt.Errorf("ListCommandInvocations failed: %w", pollErr)
 	}
 
-	// Healthy and already-marked instances are the common, non-actionable
+	// Healthy and draining instances are the common, non-actionable
 	// cases; collect them and log one summary line each instead of one line
 	// per instance.
-	var healthy, alreadyMarked []string
+	var healthy, draining []string
 
 	for _, instanceID := range onlineIDs {
 		inv, ok := results[instanceID]
@@ -321,34 +334,33 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 			}
 			continue
 		}
-		switch inv.Status {
-		case ssmTypes.CommandInvocationStatusPending,
-			ssmTypes.CommandInvocationStatusInProgress,
-			ssmTypes.CommandInvocationStatusDelayed,
-			ssmTypes.CommandInvocationStatusCancelling:
-			log.Printf("[Elastic CI Mode] Invocation for %s did not terminate (status: %s); skipping", instanceID, inv.Status)
+
+		output := strings.TrimSpace(pluginOutput(inv))
+		if inv.Status != ssmTypes.CommandInvocationStatusSuccess {
+			log.Printf("[Elastic CI Mode] Invocation for %s was inconclusive (status: %s, details: %s, output: %q); skipping", instanceID, inv.Status, aws.ToString(inv.StatusDetails), output)
 			if firstError == nil {
-				firstError = fmt.Errorf("invocation for %s did not terminate (status: %s)", instanceID, inv.Status)
+				firstError = fmt.Errorf("invocation for %s was inconclusive (status: %s, details: %s)", instanceID, inv.Status, aws.ToString(inv.StatusDetails))
 			}
 			continue
 		}
 
-		checkedCount++
-		output := pluginOutput(inv)
-
-		// Agent service isn't running (script printed NOT_RUNNING) or the
-		// command itself failed (e.g. script error / unsupported platform).
-		isDangling := inv.Status == ssmTypes.CommandInvocationStatusFailed ||
-			(inv.Status == ssmTypes.CommandInvocationStatusSuccess && strings.Contains(output, "NOT_RUNNING"))
-
-		if !isDangling {
-			// A marker means a previous run already flagged this instance for
-			// termination; the script exits before checking the agent, so we
-			// can't claim it's running.
-			if strings.Contains(output, "MARKER_EXISTS") {
-				alreadyMarked = append(alreadyMarked, instanceID)
-			} else {
-				healthy = append(healthy, instanceID)
+		switch {
+		case output == "RUNNING":
+			checkedCount++
+			healthy = append(healthy, instanceID)
+			continue
+		case output == "DRAINING" || strings.HasPrefix(output, "DRAINING:"):
+			checkedCount++
+			drainingCount++
+			draining = append(draining, instanceID)
+			continue
+		case output == "NOT_RUNNING" || strings.HasPrefix(output, "NOT_RUNNING:"):
+			// A successful probe found no agent process, so there are no jobs
+			// to drain before the ASG replaces this instance.
+		default:
+			log.Printf("[Elastic CI Mode] Invocation for %s returned inconclusive output %q; skipping", instanceID, output)
+			if firstError == nil {
+				firstError = fmt.Errorf("invocation for %s returned inconclusive output %q", instanceID, output)
 			}
 			continue
 		}
@@ -364,6 +376,7 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 			}
 		} else {
 			log.Printf("[Elastic CI Mode] Marked instance %s as unhealthy", instanceID)
+			checkedCount++
 			markedUnhealthyCount++
 		}
 	}
@@ -371,11 +384,11 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 	if len(healthy) > 0 {
 		log.Printf("[Elastic CI Mode] %d instance(s) healthy: %v", len(healthy), healthy)
 	}
-	if len(alreadyMarked) > 0 {
-		log.Printf("[Elastic CI Mode] ℹ️ %d instance(s) already marked for termination, skipping: %v", len(alreadyMarked), alreadyMarked)
+	if len(draining) > 0 {
+		log.Printf("[Elastic CI Mode] ℹ️ %d instance(s) draining: %v", len(draining), draining)
 	}
 
-	return markedUnhealthyCount, checkedCount, firstError
+	return markedUnhealthyCount, checkedCount, drainingCount, firstError
 }
 
 func (a *ASGDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, error) {
@@ -611,9 +624,6 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 		return instancesToConsiderChecking[i].LaunchTime.Before(*instancesToConsiderChecking[j].LaunchTime)
 	})
 
-	totalMarkedUnhealthy := 0
-	var firstErrorEncountered error
-
 	// Pick a sliding slice so oldest-N instances stuck failing SSM checks
 	// don't block the rest of the fleet from ever being examined.
 	instancesToCheck := rotateInstanceWindow(instancesToConsiderChecking, maxDanglingInstancesToCheck, a.DanglingInstancesCheckInterval, time.Now())
@@ -623,28 +633,13 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 		instancesForSSMCheck = append(instancesForSSMCheck, *instance.InstanceId)
 	}
 
-	totalChecked := 0
+	log.Printf("[Elastic CI Mode] Checking %d %s instance(s) for dangling agents: %v", len(instancesForSSMCheck), platform, instancesForSSMCheck)
+	markedUnhealthy, checked, draining, checkErr := a.checkAndMarkUnhealthy(ctx, instancesForSSMCheck, ssmClient, asgClient, platform)
+	healthy := checked - draining - markedUnhealthy
+	skipped := len(instancesForSSMCheck) - checked
+	log.Printf("[Elastic CI Mode] Dangling instance check complete: %d healthy, %d draining, %d marked unhealthy, %d skipped (of %d instance(s))", healthy, draining, markedUnhealthy, skipped, len(instancesForSSMCheck))
 
-	if len(instancesForSSMCheck) > 0 {
-		log.Printf("[Elastic CI Mode] Checking %d %s instance(s) for dangling agents: %v", len(instancesForSSMCheck), platform, instancesForSSMCheck)
-		markedInCall, checkedInCall, errInCall := a.checkAndMarkUnhealthy(ctx, instancesForSSMCheck, ssmClient, asgClient, platform)
-		totalMarkedUnhealthy += markedInCall
-		totalChecked += checkedInCall
-		if errInCall != nil {
-			firstErrorEncountered = errInCall
-		}
-	}
-
-	skipped := len(instancesForSSMCheck) - totalChecked
-	if totalMarkedUnhealthy > 0 {
-		log.Printf("[Elastic CI Mode] Dangling instance check: marked %d of %d checked instance(s) as unhealthy (%d skipped due to errors)", totalMarkedUnhealthy, totalChecked, skipped)
-	} else if skipped > 0 {
-		log.Printf("[Elastic CI Mode] Dangling instance check complete: %d of %d instance(s) checked and healthy, %d skipped due to errors", totalChecked, len(instancesForSSMCheck), skipped)
-	} else {
-		log.Printf("[Elastic CI Mode] Dangling instance check complete: all %d instance(s) healthy", totalChecked)
-	}
-
-	return firstErrorEncountered
+	return checkErr
 }
 
 // describeInstancesAPI is the subset of ec2.Client used by describeInstancesTolerant.

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -100,6 +100,11 @@ func (a *ASGDriver) getASGPlatform(ctx context.Context, instances []ec2Types.Ins
 	return "linux"
 }
 
+// terminationMarkerPath is created by the graceful-stop script sent from
+// SendSIGTERMToAgents and probed by the dangling-instance check script, so
+// both sides of the drain handshake must agree on it.
+const terminationMarkerPath = "/tmp/buildkite-agent-termination-marker"
+
 // getCheckCommand returns the appropriate check command for the platform
 func (a *ASGDriver) getCheckCommand(platform string) string {
 	if platform == "windows" {
@@ -131,7 +136,7 @@ case "$ACTIVE_STATE:$MAIN_PID" in
 esac
 
 if [ "$MAIN_PID" != "0" ] || [ "$ACTIVE_STATE" = "activating" ]; then
-  if [ -f /tmp/buildkite-agent-termination-marker ]; then
+  if [ -f ` + terminationMarkerPath + ` ]; then
     echo "DRAINING: ActiveState=$ACTIVE_STATE MainPID=$MAIN_PID"
   else
     echo "RUNNING"
@@ -547,11 +552,11 @@ func (a *ASGDriver) SendSIGTERMToAgents(ctx context.Context, instanceID string) 
 	// With consecutive Lambda invocations the same instance selected for scale-in,
 	// only during the first invocation will actually signal the agent to finish current jobs and stop.
 	command := `#!/bin/bash
-if [ -f /tmp/buildkite-agent-termination-marker ]; then
+if [ -f ` + terminationMarkerPath + ` ]; then
   echo "Already marked for termination, skipping"
   exit 0
 fi
-echo "Termination requested at $(date)" > /tmp/buildkite-agent-termination-marker
+echo "Termination requested at $(date)" > ` + terminationMarkerPath + `
 sudo systemctl stop buildkite-agent.service || sudo /opt/buildkite-agent/bin/buildkite-agent stop --signal SIGTERM
 `
 	log.Printf("[Elastic CI Mode] Sending SIGTERM to instance %s", instanceID)

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -255,6 +255,16 @@ func pluginOutput(inv ssmTypes.CommandInvocation) string {
 	return b.String()
 }
 
+// danglingCheckResult counts the conclusive outcomes of one dangling-instance
+// sweep. Instances whose probe failed, was ambiguous, or whose unhealthy mark
+// could not be applied appear in no bucket; the caller derives the skipped
+// count from the total it submitted.
+type danglingCheckResult struct {
+	healthy         int
+	draining        int
+	markedUnhealthy int
+}
+
 // checkAndMarkUnhealthy probes buildkite-agent on each instance via SSM and
 // marks unhealthy any whose agent service is not running, so the ASG
 // terminates and replaces them. Skipping graceful shutdown is safe here: a
@@ -273,20 +283,20 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 	ssmSvc ssmCheckAPI,
 	asgSvc asgHealthAPI,
 	platform string,
-) (markedUnhealthyCount int, checkedCount int, drainingCount int, firstError error) {
+) (result danglingCheckResult, firstError error) {
 	if len(instances) == 0 {
-		return 0, 0, 0, nil
+		return danglingCheckResult{}, nil
 	}
 
 	onlineIDs, err := filterOnlineSSMInstances(ctx, ssmSvc, instances)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("DescribeInstanceInformation failed: %w", err)
+		return danglingCheckResult{}, fmt.Errorf("DescribeInstanceInformation failed: %w", err)
 	}
 	if offline := len(instances) - len(onlineIDs); offline > 0 {
 		log.Printf("[Elastic CI Mode] SSM agent not online for %d of %d instance(s); skipping those", offline, len(instances))
 	}
 	if len(onlineIDs) == 0 {
-		return 0, 0, 0, nil
+		return danglingCheckResult{}, nil
 	}
 
 	documentName := "AWS-RunShellScript"
@@ -306,7 +316,7 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 			Comment:      aws.String("Check if buildkite-agent service is running"),
 		})
 		if err != nil {
-			return 0, 0, 0, fmt.Errorf("SendCommand failed: %w", err)
+			return danglingCheckResult{}, fmt.Errorf("SendCommand failed: %w", err)
 		}
 		commandIDs = append(commandIDs, *sendOut.Command.CommandId)
 	}
@@ -351,12 +361,9 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 
 		switch {
 		case output == "RUNNING":
-			checkedCount++
 			healthy = append(healthy, instanceID)
 			continue
 		case output == "DRAINING" || strings.HasPrefix(output, "DRAINING:"):
-			checkedCount++
-			drainingCount++
 			draining = append(draining, instanceID)
 			continue
 		case output == "NOT_RUNNING" || strings.HasPrefix(output, "NOT_RUNNING:"):
@@ -381,8 +388,7 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 			}
 		} else {
 			log.Printf("[Elastic CI Mode] Marked instance %s as unhealthy", instanceID)
-			checkedCount++
-			markedUnhealthyCount++
+			result.markedUnhealthy++
 		}
 	}
 
@@ -393,7 +399,9 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 		log.Printf("[Elastic CI Mode] ℹ️ %d instance(s) draining: %v", len(draining), draining)
 	}
 
-	return markedUnhealthyCount, checkedCount, drainingCount, firstError
+	result.healthy = len(healthy)
+	result.draining = len(draining)
+	return result, firstError
 }
 
 func (a *ASGDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, error) {
@@ -639,10 +647,9 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 	}
 
 	log.Printf("[Elastic CI Mode] Checking %d %s instance(s) for dangling agents: %v", len(instancesForSSMCheck), platform, instancesForSSMCheck)
-	markedUnhealthy, checked, draining, checkErr := a.checkAndMarkUnhealthy(ctx, instancesForSSMCheck, ssmClient, asgClient, platform)
-	healthy := checked - draining - markedUnhealthy
-	skipped := len(instancesForSSMCheck) - checked
-	log.Printf("[Elastic CI Mode] Dangling instance check complete: %d healthy, %d draining, %d marked unhealthy, %d skipped (of %d instance(s))", healthy, draining, markedUnhealthy, skipped, len(instancesForSSMCheck))
+	result, checkErr := a.checkAndMarkUnhealthy(ctx, instancesForSSMCheck, ssmClient, asgClient, platform)
+	skipped := len(instancesForSSMCheck) - result.healthy - result.draining - result.markedUnhealthy
+	log.Printf("[Elastic CI Mode] Dangling instance check complete: %d healthy, %d draining, %d marked unhealthy, %d skipped (of %d instance(s))", result.healthy, result.draining, result.markedUnhealthy, skipped, len(instancesForSSMCheck))
 
 	return checkErr
 }

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -340,6 +340,16 @@ printf 'ActiveState=%s\nMainPID=%s\n' "$ACTIVE_STATE" "$MAIN_PID"
 		{name: "draining", activeState: "active", mainPID: "123", marker: true, want: "DRAINING: ActiveState=active MainPID=123"},
 		{name: "marked but stopped", activeState: "inactive", mainPID: "0", marker: true, want: "NOT_RUNNING: ActiveState=inactive"},
 		{name: "activating", activeState: "activating", mainPID: "0", marker: true, want: "DRAINING: ActiveState=activating MainPID=0"},
+		// A live process in deactivating may still be draining a job, so it
+		// must not be classified NOT_RUNNING while the PID exists.
+		{name: "deactivating without marker", activeState: "deactivating", mainPID: "123", want: "RUNNING"},
+		// The normal graceful scale-in window: marker written, systemd
+		// stopping the unit, agent finishing its last job.
+		{name: "deactivating with marker", activeState: "deactivating", mainPID: "123", marker: true, want: "DRAINING: ActiveState=deactivating MainPID=123"},
+		{name: "failed unit", activeState: "failed", mainPID: "0", want: "NOT_RUNNING: ActiveState=failed"},
+		// Type=simple assumption: active with MainPID=0 means the process is
+		// gone even though systemd still reports the unit active.
+		{name: "active without main PID", activeState: "active", mainPID: "0", want: "NOT_RUNNING: ActiveState=active"},
 		{name: "systemctl failure", systemctlErr: "systemctl unavailable", want: "UNKNOWN: systemctl unavailable"},
 		{name: "malformed PID", activeState: "active", mainPID: "invalid", want: "UNKNOWN: ActiveState=active MainPID=invalid"},
 	}

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -647,14 +647,14 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 		}
 		asgStub := &stubASGClient{}
 
-		marked, checked, draining, err := driver.checkAndMarkUnhealthy(ctx,
+		result, err := driver.checkAndMarkUnhealthy(ctx,
 			[]string{"i-dangling", "i-healthy", "i-draining"},
 			ssmStub, asgStub, "linux")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if marked != 1 || checked != 3 || draining != 1 {
-			t.Errorf("marked = %d, checked = %d, draining = %d; want 1, 3, 1", marked, checked, draining)
+		if want := (danglingCheckResult{healthy: 1, draining: 1, markedUnhealthy: 1}); result != want {
+			t.Errorf("result = %+v, want %+v", result, want)
 		}
 		if !slices.Equal(asgStub.markedUnhealthy, []string{"i-dangling"}) {
 			t.Errorf("marked unhealthy = %v, want [i-dangling]", asgStub.markedUnhealthy)
@@ -678,19 +678,19 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 		}
 		asgStub := &stubASGClient{}
 
-		marked, checked, draining, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, asgStub, "linux")
+		result, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, asgStub, "linux")
 		if err == nil {
 			t.Fatal("expected an inconclusive-result error")
 		}
-		if marked != 0 || checked != 0 || draining != 0 {
-			t.Errorf("marked = %d, checked = %d, draining = %d; want 0, 0, 0", marked, checked, draining)
+		if result != (danglingCheckResult{}) {
+			t.Errorf("result = %+v, want all zero", result)
 		}
 		if len(asgStub.markedUnhealthy) != 0 {
 			t.Errorf("marked unhealthy = %v, want none", asgStub.markedUnhealthy)
 		}
 	})
 
-	t.Run("does not count a failed unhealthy mark as checked", func(t *testing.T) {
+	t.Run("excludes a failed unhealthy mark from every bucket", func(t *testing.T) {
 		ssmStub := &stubSSMClient{
 			describeOut: online("i-dangling"),
 			listResponses: []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{
@@ -701,12 +701,12 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 		}
 		asgStub := &stubASGClient{setHealthErr: errors.New("unavailable")}
 
-		marked, checked, draining, err := driver.checkAndMarkUnhealthy(ctx, []string{"i-dangling"}, ssmStub, asgStub, "linux")
+		result, err := driver.checkAndMarkUnhealthy(ctx, []string{"i-dangling"}, ssmStub, asgStub, "linux")
 		if err == nil {
 			t.Fatal("expected SetInstanceHealth error")
 		}
-		if marked != 0 || checked != 0 || draining != 0 {
-			t.Errorf("marked = %d, checked = %d, draining = %d; want 0, 0, 0", marked, checked, draining)
+		if result != (danglingCheckResult{}) {
+			t.Errorf("result = %+v, want all zero", result)
 		}
 	})
 
@@ -722,7 +722,7 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 			listResponses: []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{CommandInvocations: invs}}},
 		}
 
-		_, checked, _, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, &stubASGClient{}, "linux")
+		result, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, &stubASGClient{}, "linux")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -734,8 +734,8 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 		if !slices.Equal(gotSizes, []int{50, 1}) {
 			t.Errorf("SendCommand batch sizes = %v, want [50 1]", gotSizes)
 		}
-		if checked != 51 {
-			t.Errorf("checkedCount = %d, want 51", checked)
+		if result.healthy != 51 {
+			t.Errorf("healthy = %d, want 51", result.healthy)
 		}
 	})
 }

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -353,7 +353,7 @@ printf 'ActiveState=%s\nMainPID=%s\n' "$ACTIVE_STATE" "$MAIN_PID"
 				}
 			}
 
-			script := strings.ReplaceAll((&ASGDriver{}).getCheckCommand("linux"), "/tmp/buildkite-agent-termination-marker", marker)
+			script := strings.ReplaceAll((&ASGDriver{}).getCheckCommand("linux"), terminationMarkerPath, marker)
 			cmd := exec.Command("bash", "-c", script)
 			cmd.Env = append(os.Environ(),
 				"PATH="+binDir+":"+os.Getenv("PATH"),

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -271,11 +274,11 @@ func TestGetCheckCommand(t *testing.T) {
 				"ActiveState",
 				"RUNNING",
 				"NOT_RUNNING",
-				"MARKER_EXISTS",
 			},
 			expectedNotContains: []string{
 				"PowerShell",
 				"Get-Service",
+				"MARKER_EXISTS",
 			},
 		},
 		{
@@ -308,6 +311,62 @@ func TestGetCheckCommand(t *testing.T) {
 				if strings.Contains(cmd, notExpected) {
 					t.Errorf("expected command NOT to contain %q, but it did.\nCommand: %s", notExpected, cmd)
 				}
+			}
+		})
+	}
+}
+
+func TestLinuxCheckCommand(t *testing.T) {
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "systemctl"), []byte(`#!/bin/sh
+if [ -n "$SYSTEMCTL_ERROR" ]; then
+  echo "$SYSTEMCTL_ERROR"
+  exit 1
+fi
+printf 'ActiveState=%s\nMainPID=%s\n' "$ACTIVE_STATE" "$MAIN_PID"
+`), 0o755); err != nil {
+		t.Fatalf("write systemctl stub: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		activeState  string
+		mainPID      string
+		marker       bool
+		systemctlErr string
+		want         string
+	}{
+		{name: "running", activeState: "active", mainPID: "123", want: "RUNNING"},
+		{name: "draining", activeState: "active", mainPID: "123", marker: true, want: "DRAINING: ActiveState=active MainPID=123"},
+		{name: "marked but stopped", activeState: "inactive", mainPID: "0", marker: true, want: "NOT_RUNNING: ActiveState=inactive"},
+		{name: "activating", activeState: "activating", mainPID: "0", marker: true, want: "DRAINING: ActiveState=activating MainPID=0"},
+		{name: "systemctl failure", systemctlErr: "systemctl unavailable", want: "UNKNOWN: systemctl unavailable"},
+		{name: "malformed PID", activeState: "active", mainPID: "invalid", want: "UNKNOWN: ActiveState=active MainPID=invalid"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			marker := filepath.Join(t.TempDir(), "termination-marker")
+			if tc.marker {
+				if err := os.WriteFile(marker, nil, 0o600); err != nil {
+					t.Fatalf("write termination marker: %v", err)
+				}
+			}
+
+			script := strings.ReplaceAll((&ASGDriver{}).getCheckCommand("linux"), "/tmp/buildkite-agent-termination-marker", marker)
+			cmd := exec.Command("bash", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"PATH="+binDir+":"+os.Getenv("PATH"),
+				"ACTIVE_STATE="+tc.activeState,
+				"MAIN_PID="+tc.mainPID,
+				"SYSTEMCTL_ERROR="+tc.systemctlErr,
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("run check command: %v\n%s", err, out)
+			}
+			if got := strings.TrimSpace(string(out)); got != tc.want {
+				t.Errorf("output = %q, want %q", got, tc.want)
 			}
 		})
 	}
@@ -575,40 +634,79 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 		}
 	}
 
-	t.Run("marks dangling instances and skips healthy or already-marked", func(t *testing.T) {
+	t.Run("classifies conclusive results", func(t *testing.T) {
 		ssmStub := &stubSSMClient{
-			describeOut: online("i-dangling", "i-healthy", "i-failed", "i-marked"),
+			describeOut: online("i-dangling", "i-healthy", "i-draining"),
 			listResponses: []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{
 				CommandInvocations: []ssmTypes.CommandInvocation{
 					invOut("i-dangling", ssmTypes.CommandInvocationStatusSuccess, "NOT_RUNNING: dead"),
 					invOut("i-healthy", ssmTypes.CommandInvocationStatusSuccess, "RUNNING"),
-					invOut("i-failed", ssmTypes.CommandInvocationStatusFailed, ""),
-					invOut("i-marked", ssmTypes.CommandInvocationStatusSuccess, "MARKER_EXISTS: already marked"),
+					invOut("i-draining", ssmTypes.CommandInvocationStatusSuccess, "DRAINING: ActiveState=active MainPID=123"),
 				},
 			}}},
 		}
 		asgStub := &stubASGClient{}
 
-		// i-offline is not in the describe output, so it should be filtered out.
-		marked, checked, err := driver.checkAndMarkUnhealthy(ctx,
-			[]string{"i-dangling", "i-healthy", "i-failed", "i-marked", "i-offline"},
+		marked, checked, draining, err := driver.checkAndMarkUnhealthy(ctx,
+			[]string{"i-dangling", "i-healthy", "i-draining"},
 			ssmStub, asgStub, "linux")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if checked != 4 {
-			t.Errorf("checkedCount = %d, want 4", checked)
+		if marked != 1 || checked != 3 || draining != 1 {
+			t.Errorf("marked = %d, checked = %d, draining = %d; want 1, 3, 1", marked, checked, draining)
 		}
-		if marked != 2 {
-			t.Errorf("markedUnhealthyCount = %d, want 2", marked)
+		if !slices.Equal(asgStub.markedUnhealthy, []string{"i-dangling"}) {
+			t.Errorf("marked unhealthy = %v, want [i-dangling]", asgStub.markedUnhealthy)
 		}
-		got := slices.Clone(asgStub.markedUnhealthy)
-		sort.Strings(got)
-		if !slices.Equal(got, []string{"i-dangling", "i-failed"}) {
-			t.Errorf("marked unhealthy = %v, want [i-dangling i-failed]", got)
+	})
+
+	t.Run("treats failed or ambiguous results as inconclusive", func(t *testing.T) {
+		ids := []string{"i-failed", "i-timed-out", "i-future-status", "i-empty", "i-ambiguous", "i-unknown"}
+		ssmStub := &stubSSMClient{
+			describeOut: online(ids...),
+			listResponses: []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{
+				CommandInvocations: []ssmTypes.CommandInvocation{
+					invOut("i-failed", ssmTypes.CommandInvocationStatusFailed, "NOT_RUNNING: dead"),
+					invOut("i-timed-out", ssmTypes.CommandInvocationStatusTimedOut, ""),
+					invOut("i-future-status", ssmTypes.CommandInvocationStatus("FutureStatus"), ""),
+					invOut("i-empty", ssmTypes.CommandInvocationStatusSuccess, ""),
+					invOut("i-ambiguous", ssmTypes.CommandInvocationStatusSuccess, "RUNNING: maybe"),
+					invOut("i-unknown", ssmTypes.CommandInvocationStatusSuccess, "UNKNOWN: systemctl failed"),
+				},
+			}}},
 		}
-		if len(ssmStub.sendBatches) != 1 || len(ssmStub.sendBatches[0]) != 4 {
-			t.Errorf("expected one SendCommand of 4 instances, got %v", ssmStub.sendBatches)
+		asgStub := &stubASGClient{}
+
+		marked, checked, draining, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, asgStub, "linux")
+		if err == nil {
+			t.Fatal("expected an inconclusive-result error")
+		}
+		if marked != 0 || checked != 0 || draining != 0 {
+			t.Errorf("marked = %d, checked = %d, draining = %d; want 0, 0, 0", marked, checked, draining)
+		}
+		if len(asgStub.markedUnhealthy) != 0 {
+			t.Errorf("marked unhealthy = %v, want none", asgStub.markedUnhealthy)
+		}
+	})
+
+	t.Run("does not count a failed unhealthy mark as checked", func(t *testing.T) {
+		ssmStub := &stubSSMClient{
+			describeOut: online("i-dangling"),
+			listResponses: []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{
+				CommandInvocations: []ssmTypes.CommandInvocation{
+					invOut("i-dangling", ssmTypes.CommandInvocationStatusSuccess, "NOT_RUNNING: dead"),
+				},
+			}}},
+		}
+		asgStub := &stubASGClient{setHealthErr: errors.New("unavailable")}
+
+		marked, checked, draining, err := driver.checkAndMarkUnhealthy(ctx, []string{"i-dangling"}, ssmStub, asgStub, "linux")
+		if err == nil {
+			t.Fatal("expected SetInstanceHealth error")
+		}
+		if marked != 0 || checked != 0 || draining != 0 {
+			t.Errorf("marked = %d, checked = %d, draining = %d; want 0, 0, 0", marked, checked, draining)
 		}
 	})
 
@@ -624,7 +722,7 @@ func TestCheckAndMarkUnhealthy(t *testing.T) {
 			listResponses: []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{CommandInvocations: invs}}},
 		}
 
-		_, checked, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, &stubASGClient{}, "linux")
+		_, checked, _, err := driver.checkAndMarkUnhealthy(ctx, ids, ssmStub, &stubASGClient{}, "linux")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -240,6 +240,10 @@ func (s *Scaler) Run(ctx context.Context) (time.Duration, error) {
 	if instanceCount == 0 {
 		instanceCount = asg.DesiredCount
 	}
+	if asg.DesiredCount == desired && instanceCount != desired {
+		log.Printf("ASG is converging to desired capacity %d (currently %d running instances)", desired, instanceCount)
+		return metrics.PollDuration, nil
+	}
 
 	if desired > instanceCount {
 		log.Printf("Scaling decision: calculated desired %d instances. ASG current desired: %d, ASG actual running: %d (approx %d agents), Buildkite scheduled: %d, running: %d, waiting: %d",
@@ -248,24 +252,9 @@ func (s *Scaler) Run(ctx context.Context) (time.Duration, error) {
 		if desired > asg.DesiredCount {
 			log.Printf(" Action: Scale out from %d to %d", asg.DesiredCount, desired)
 			return metrics.PollDuration, s.scaleOut(ctx, desired, asg)
-		} else if desired < asg.DesiredCount {
-			log.Printf(" Action: Scale in from %d to %d", asg.DesiredCount, desired)
-			return metrics.PollDuration, s.scaleIn(ctx, desired, asg)
-		} else {
-			log.Printf(" Action: No change needed. Desired capacity %d matches ASG desired %d.", desired, asg.DesiredCount)
 		}
-
-		// The following block handles a scenario where desired == asg.DesiredCount, but instanceCount might be different
-		// (e.g. instances still launching or terminating).
-		// If instanceCount > desired (and desired == asg.DesiredCount), it implies instances might be terminating slowly or stuck.
-		// If instanceCount < desired (and desired == asg.DesiredCount), it implies instances might be launching slowly.
-		// In these cases, no direct scaling action is taken here as the ASG is already set to the correct desired count.
-		if instanceCount > desired && asg.DesiredCount == desired {
-			log.Printf("INFO: Instance count (%d) > desired (%d), but ASG desired count (%d) already matches. ASG may be converging.", instanceCount, desired, asg.DesiredCount)
-		} else if instanceCount < desired && asg.DesiredCount == desired {
-			log.Printf("INFO: Instance count (%d) < desired (%d), but ASG desired count (%d) already matches. ASG may be converging.", instanceCount, desired, asg.DesiredCount)
-		}
-		return metrics.PollDuration, nil
+		log.Printf(" Action: Scale in from %d to %d", asg.DesiredCount, desired)
+		return metrics.PollDuration, s.scaleIn(ctx, desired, asg)
 	}
 
 	if asg.DesiredCount > desired {
@@ -362,14 +351,14 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 
 				// Check if we're in cooldown period based on the last ASG scale-in activity
 				if s.scaleInParams.CooldownPeriod > 0 && timeSinceLastScaleIn < s.scaleInParams.CooldownPeriod {
-					log.Printf("⏲ [Elastic CI Mode] Last ASG scale-in was %s ago, in cooldown period for %s more (cooldown: %s)",
+					log.Printf("⏲ [Elastic CI Mode] Last successful ASG scale-in was %s ago, in cooldown period for %s more (cooldown: %s)",
 						timeSinceLastScaleIn.Round(time.Second),
 						(s.scaleInParams.CooldownPeriod - timeSinceLastScaleIn).Round(time.Second),
 						s.scaleInParams.CooldownPeriod)
 					return nil
 				}
 
-				log.Printf("[Elastic CI Mode] Last ASG scale-in was %s ago", timeSinceLastScaleIn.Round(time.Second))
+				log.Printf("[Elastic CI Mode] Last successful ASG scale-in was %s ago", timeSinceLastScaleIn.Round(time.Second))
 			}
 		}
 	}

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -449,13 +449,14 @@ func (d *buildkiteTestDriver) GetAgentMetrics(ctx context.Context) (buildkite.Ag
 }
 
 type asgTestDriver struct {
-	err                    error
-	desiredCapacity        int64
-	actualCapacity         int64 // If 0, will default to desiredCapacity
-	maxSize                int64 // If 0, defaults to 100
-	sigTermsSent           []string
-	elasticCIMode          bool
-	danglingInstancesFound int
+	err                     error
+	desiredCapacity         int64
+	actualCapacity          int64 // If 0, will default to desiredCapacity
+	maxSize                 int64 // If 0, defaults to 100
+	sigTermsSent            []string
+	setDesiredCapacityCalls int
+	elasticCIMode           bool
+	danglingInstancesFound  int
 }
 
 func (d *asgTestDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, error) {
@@ -485,6 +486,7 @@ func (d *asgTestDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, er
 }
 
 func (d *asgTestDriver) SetDesiredCapacity(ctx context.Context, count int64) error {
+	d.setDesiredCapacityCalls++
 	d.desiredCapacity = count
 	return d.err
 }
@@ -500,6 +502,82 @@ func (d *asgTestDriver) SendSIGTERMToAgents(ctx context.Context, instanceID stri
 func (d *asgTestDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanceUptime time.Duration, maxDanglingInstancesToCheck int) error {
 	d.danglingInstancesFound++
 	return d.err
+}
+
+// TestScaleInWhileASGConverging pins the early return in Run that suppresses
+// repeated scaling while the ASG is still converging on a previously set
+// desired capacity. It must fire only when the computed desired count equals
+// the ASG's desired count, and must never swallow a real scale-in.
+func TestScaleInWhileASGConverging(t *testing.T) {
+	testCases := []struct {
+		name                     string
+		asgDesired               int64
+		asgActual                int64
+		expectedDesiredCapacity  int64
+		expectedSetCapacityCalls int
+	}{
+		// The ASG was already told to shrink to 3 and 5 instances are still
+		// running: the scaler must wait, not issue another scale-in.
+		{
+			name:                     "no scale-in while converging down",
+			asgDesired:               3,
+			asgActual:                5,
+			expectedDesiredCapacity:  3,
+			expectedSetCapacityCalls: 0,
+		},
+		// Converging up: desired already 3, only 2 running yet. If the
+		// converging guard ever moves below the desired > instanceCount
+		// branch, this case would fall through to scaleIn.
+		{
+			name:                     "no scale-in while converging up",
+			asgDesired:               3,
+			asgActual:                2,
+			expectedDesiredCapacity:  3,
+			expectedSetCapacityCalls: 0,
+		},
+		// The ASG desired count is above the computed desired count, so a
+		// real scale-in must still fire despite actual == computed desired.
+		{
+			name:                     "scale-in fires when ASG desired exceeds computed desired",
+			asgDesired:               5,
+			asgActual:                3,
+			expectedDesiredCapacity:  3,
+			expectedSetCapacityCalls: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			asg := &asgTestDriver{
+				desiredCapacity: tc.asgDesired,
+				actualCapacity:  tc.asgActual,
+			}
+			s := Scaler{
+				autoscaling: asg,
+				// ScheduledJobs 3 with one agent per instance computes a
+				// desired count of 3 in every case.
+				bk: &buildkiteTestDriver{metrics: buildkite.AgentMetrics{
+					ScheduledJobs: 3,
+				}},
+				scaling: ScalingCalculator{agentsPerInstance: 1},
+			}
+
+			if _, err := s.Run(context.Background()); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if asg.setDesiredCapacityCalls != tc.expectedSetCapacityCalls {
+				t.Errorf("SetDesiredCapacity calls = %d, want %d",
+					asg.setDesiredCapacityCalls, tc.expectedSetCapacityCalls)
+			}
+			if asg.desiredCapacity != tc.expectedDesiredCapacity {
+				t.Errorf("desired capacity = %d, want %d",
+					asg.desiredCapacity, tc.expectedDesiredCapacity)
+			}
+			if len(asg.sigTermsSent) != 0 {
+				t.Errorf("SIGTERMs sent to %v, want none", asg.sigTermsSent)
+			}
+		})
+	}
 }
 
 func TestAvailabilityBasedScaling(t *testing.T) {


### PR DESCRIPTION
## Why

The termination marker only tells us SIGTERM was sent; it doesn't tell us whether the agent is still running. Dangling cleanup could therefore keep skipping a marked instance after its agent had stopped.

## What

- Treat a marked, running agent as draining.
- Mark instances with stopped agents as unhealthy for replacement.
- Skip failed or ambiguous SSM checks rather than guessing.
- Avoid repeated scale-in attempts while the ASG is already converging, and clarify the related logs.

Tested end-to-end on an Elastic CI Stack: a busy agent received one SIGTERM and drained normally, while dangling cleanup replaced a stopped agent without sending another SIGTERM.