### PR TITLE
Route scaling by ASG desired capacity

### DIFF
--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -245,23 +245,14 @@ func (s *Scaler) Run(ctx context.Context) (time.Duration, error) {
 		return metrics.PollDuration, nil
 	}
 
-	if desired > instanceCount {
+	if desired > asg.DesiredCount {
 		log.Printf("Scaling decision: calculated desired %d instances. ASG current desired: %d, ASG actual running: %d (approx %d agents), Buildkite scheduled: %d, running: %d, waiting: %d",
 			desired, asg.DesiredCount, instanceCount, instanceCount*int64(s.scaling.agentsPerInstance), metrics.ScheduledJobs, metrics.RunningJobs, metrics.WaitingJobs)
-
-		if desired > asg.DesiredCount {
-			log.Printf(" Action: Scale out from %d to %d", asg.DesiredCount, desired)
-			return metrics.PollDuration, s.scaleOut(ctx, desired, asg)
-		}
-		log.Printf(" Action: Scale in from %d to %d", asg.DesiredCount, desired)
-		return metrics.PollDuration, s.scaleIn(ctx, desired, asg)
+		log.Printf(" Action: Scale out from %d to %d", asg.DesiredCount, desired)
+		return metrics.PollDuration, s.scaleOut(ctx, desired, asg)
 	}
 
 	if asg.DesiredCount > desired {
-		return metrics.PollDuration, s.scaleIn(ctx, desired, asg)
-	}
-
-	if instanceCount > desired {
 		// In Elastic CI mode, check for pending instances before scaling down
 		// If there are pending instances, it means ASG is already scaling, so we should wait
 		if s.elasticCIMode && asg.Pending > 0 {
@@ -269,8 +260,7 @@ func (s *Scaler) Run(ctx context.Context) (time.Duration, error) {
 			return metrics.PollDuration, nil
 		}
 
-		log.Printf("Scaling decision: need %d instances, have %d actual running instances (desired set to %d)",
-			desired, instanceCount, asg.DesiredCount)
+		log.Printf(" Action: Scale in from %d to %d", asg.DesiredCount, desired)
 		return metrics.PollDuration, s.scaleIn(ctx, desired, asg)
 	}
 

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -452,6 +452,7 @@ type asgTestDriver struct {
 	err                     error
 	desiredCapacity         int64
 	actualCapacity          int64 // If 0, will default to desiredCapacity
+	pendingCapacity         int64
 	maxSize                 int64 // If 0, defaults to 100
 	sigTermsSent            []string
 	setDesiredCapacityCalls int
@@ -477,6 +478,7 @@ func (d *asgTestDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, er
 	}
 
 	return AutoscaleGroupDetails{
+		Pending:      d.pendingCapacity,
 		DesiredCount: d.desiredCapacity,
 		ActualCount:  actualCount,
 		MinSize:      0,
@@ -577,6 +579,69 @@ func TestScaleInWhileASGConverging(t *testing.T) {
 				t.Errorf("SIGTERMs sent to %v, want none", asg.sigTermsSent)
 			}
 		})
+	}
+}
+
+func TestScalerRunScalesOutWhenTargetExceedsASGDesired(t *testing.T) {
+	lastScaleIn := time.Now()
+	asg := &asgTestDriver{
+		desiredCapacity: 2,
+		actualCapacity:  5,
+	}
+	s := Scaler{
+		autoscaling: asg,
+		// Three scheduled jobs with one agent per instance require three
+		// instances: above ASG desired capacity, but below actual capacity.
+		bk: &buildkiteTestDriver{metrics: buildkite.AgentMetrics{
+			ScheduledJobs: 3,
+		}},
+		scaling: ScalingCalculator{agentsPerInstance: 1},
+		scaleInParams: ScaleParams{
+			CooldownPeriod: time.Hour,
+			LastEvent:      lastScaleIn,
+		},
+	}
+
+	if _, err := s.Run(t.Context()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if asg.setDesiredCapacityCalls != 1 {
+		t.Errorf("SetDesiredCapacity calls = %d, want 1", asg.setDesiredCapacityCalls)
+	}
+	if asg.desiredCapacity != 3 {
+		t.Errorf("desired capacity = %d, want 3", asg.desiredCapacity)
+	}
+	if !s.LastScaleIn().Equal(lastScaleIn) {
+		t.Errorf("last scale-in = %s, want unchanged at %s", s.LastScaleIn(), lastScaleIn)
+	}
+	if s.LastScaleOut().IsZero() {
+		t.Error("last scale-out is zero, want scale-out recorded")
+	}
+}
+
+func TestScalerRunWaitsToScaleInWhileInstancesArePending(t *testing.T) {
+	asg := &asgTestDriver{
+		desiredCapacity: 5,
+		actualCapacity:  5,
+		pendingCapacity: 1,
+	}
+	s := Scaler{
+		autoscaling: asg,
+		bk: &buildkiteTestDriver{metrics: buildkite.AgentMetrics{
+			ScheduledJobs: 3,
+		}},
+		scaling:       ScalingCalculator{agentsPerInstance: 1},
+		elasticCIMode: true,
+	}
+
+	if _, err := s.Run(t.Context()); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if asg.setDesiredCapacityCalls != 0 {
+		t.Errorf("SetDesiredCapacity calls = %d, want 0", asg.setDesiredCapacityCalls)
+	}
+	if asg.desiredCapacity != 5 {
+		t.Errorf("desired capacity = %d, want 5", asg.desiredCapacity)
 	}
 }
 


### PR DESCRIPTION
## Why

While an ASG is scaling in, actual capacity can remain above desired capacity as instances drain. The scaler can then mistake an increased target for scale-in and block it behind the scale-in cooldown.

## What

Route scaling decisions using ASG desired capacity instead of running instance count. This allows capacity to increase when demand returns while older instances are still draining.

This partially addresses [SUP-7940](https://linear.app/buildkite/issue/SUP-7940).