### PR TITLE
Terminate an unreachable last instance and confirm the probe ran

### DIFF
--- a/lambda/main.go
+++ b/lambda/main.go
@@ -128,7 +128,12 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 		defer cancel()
 
 		scalingLastActivityStartTime := time.Now()
-		scaleOutOutput, scaleInOutput, err := asg.GetLastScalingInAndOutActivity(cctx, !disableScaleOut, !disableScaleIn)
+		activityLookback := max(scaleInCooldownPeriod, scaleOutCooldownPeriod)
+		activitySince := time.Time{}
+		if activityLookback > 0 {
+			activitySince = time.Now().Add(-activityLookback)
+		}
+		scaleOutOutput, scaleInOutput, err := asg.GetLastScalingInAndOutActivity(cctx, !disableScaleOut, !disableScaleIn || elasticCIMode, activitySince)
 		if errors.Is(err, context.DeadlineExceeded) {
 			log.Printf("Failed to retrieve last scaling activity events due to %v timeout", asgActivityTimeoutDuration)
 			return
@@ -189,15 +194,17 @@ func Handler(ctx context.Context, evt json.RawMessage) (string, error) {
 			LastEvent:      lastScaleOut,
 			Disable:        disableScaleOut,
 		},
-		InstanceBuffer:                 instanceBuffer,
-		ScaleOnlyAfterAllEvent:         scaleOnlyAfterAllEvent,
-		PublishCloudWatchMetrics:       publishCloudWatchMetrics,
-		AvailabilityThreshold:          availabilityThreshold,
-		ElasticCIMode:                  elasticCIMode,
-		MinimumInstanceUptime:          minimumInstanceUptime,
-		MaxDanglingInstancesToCheck:    maxDanglingInstancesToCheck,
-		MaxInstanceCap:                 maxInstanceCap,
-		DanglingInstancesCheckInterval: interval,
+		InstanceBuffer:                    instanceBuffer,
+		ScaleOnlyAfterAllEvent:            scaleOnlyAfterAllEvent,
+		PublishCloudWatchMetrics:          publishCloudWatchMetrics,
+		AvailabilityThreshold:             availabilityThreshold,
+		ASGActivityTimeout:                asgActivityTimeoutDuration,
+		MaxDescribeScalingActivitiesPages: maxDescribeScalingActivitiesPages,
+		ElasticCIMode:                     elasticCIMode,
+		MinimumInstanceUptime:             minimumInstanceUptime,
+		MaxDanglingInstancesToCheck:       maxDanglingInstancesToCheck,
+		MaxInstanceCap:                    maxInstanceCap,
+		DanglingInstancesCheckInterval:    interval,
 	}
 
 	scaler, err := scaler.NewScaler(client, cfg, params)

--- a/main.go
+++ b/main.go
@@ -73,11 +73,12 @@ func main() {
 			Factor:         *scaleOutFactor,
 			CooldownPeriod: *scaleOutCooldown,
 		},
-		InstanceBuffer:                 *instanceBuffer,
-		ElasticCIMode:                  *elasticCIMode,
-		MinimumInstanceUptime:          *minimumInstanceUptime,
-		MaxDanglingInstancesToCheck:    *maxDanglingInstancesToCheck,
-		DanglingInstancesCheckInterval: interval,
+		InstanceBuffer:                    *instanceBuffer,
+		MaxDescribeScalingActivitiesPages: -1,
+		ElasticCIMode:                     *elasticCIMode,
+		MinimumInstanceUptime:             *minimumInstanceUptime,
+		MaxDanglingInstancesToCheck:       *maxDanglingInstancesToCheck,
+		DanglingInstancesCheckInterval:    interval,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -38,7 +38,7 @@ type AutoscaleGroupDetails struct {
 	DesiredCount int64
 	MinSize      int64
 	MaxSize      int64
-	InstanceIDs  []string // Instance IDs in the ASG
+	InstanceIDs  []string // InService instance IDs eligible for scale-in
 	ActualCount  int64    // Actual number of running instances
 }
 
@@ -58,37 +58,9 @@ type ASGDriver struct {
 	ssmPollDeadline      time.Duration
 }
 
-// waitForSSMReady blocks until the SSM agent on instanceID reports PingStatus="Online",
-// or until timeout elapses.
-func (a *ASGDriver) waitForSSMReady(ctx context.Context, instanceID string, timeout time.Duration) error {
-	ssmSvc := ssm.NewFromConfig(a.Cfg)
-	deadline := time.Now().Add(timeout)
-
-	for time.Now().Before(deadline) {
-		resp, err := ssmSvc.DescribeInstanceInformation(ctx, &ssm.DescribeInstanceInformationInput{
-			Filters: []ssmTypes.InstanceInformationStringFilter{
-				{
-					Key:    aws.String("InstanceIds"),
-					Values: []string{instanceID},
-				},
-			},
-		})
-		if err != nil {
-			log.Printf("[SSM] DescribeInstanceInformation failed for %s: %v", instanceID, err)
-		} else if len(resp.InstanceInformationList) > 0 &&
-			resp.InstanceInformationList[0].PingStatus == ssmTypes.PingStatusOnline {
-			return nil
-		}
-
-		time.Sleep(5 * time.Second)
-	}
-
-	return fmt.Errorf("timed out waiting for SSM agent to become ready on %s", instanceID)
-}
-
 // getASGPlatform detects whether the ASG contains Linux or Windows instances.
 // Since each ASG is single-platform, we only need to check one instance.
-func (a *ASGDriver) getASGPlatform(ctx context.Context, instances []ec2Types.Instance) string {
+func (a *ASGDriver) getASGPlatform(instances []ec2Types.Instance) string {
 	for _, instance := range instances {
 		// The Platform field is only set for Windows instances.
 		// Use case-insensitive comparison because the EC2 API returns "windows" (lowercase)
@@ -101,9 +73,13 @@ func (a *ASGDriver) getASGPlatform(ctx context.Context, instances []ec2Types.Ins
 }
 
 // terminationMarkerPath is created by the graceful-stop script sent from
-// SendSIGTERMToAgents and probed by the dangling-instance check script, so
-// both sides of the drain handshake must agree on it.
+// sendSIGTERMToAgentsBatch and probed by the dangling-instance check script,
+// so both sides of the drain handshake must agree on it.
 const terminationMarkerPath = "/tmp/buildkite-agent-termination-marker"
+
+// SendCommand and DescribeInstanceInformation each accept at most 50 explicit
+// instance IDs. Keep both operations on the same batch boundary.
+const ssmMaxInstanceIDs = 50
 
 // getCheckCommand returns the appropriate check command for the platform
 func (a *ASGDriver) getCheckCommand(platform string) string {
@@ -135,7 +111,7 @@ case "$ACTIVE_STATE:$MAIN_PID" in
     ;;
 esac
 
-if [ "$MAIN_PID" != "0" ] || [ "$ACTIVE_STATE" = "activating" ]; then
+if [ "$MAIN_PID" != "0" ] || [ "$ACTIVE_STATE" = "activating" ] || [ "$ACTIVE_STATE" = "deactivating" ]; then
   if [ -f ` + terminationMarkerPath + ` ]; then
     echo "DRAINING: ActiveState=$ACTIVE_STATE MainPID=$MAIN_PID"
   else
@@ -166,18 +142,29 @@ type asgHealthAPI interface {
 // SendCommand would either fail or sit Pending until it times out.
 // https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InstanceInformation.html
 func filterOnlineSSMInstances(ctx context.Context, ssmSvc ssmCheckAPI, instanceIDs []string) ([]string, error) {
-	resp, err := ssmSvc.DescribeInstanceInformation(ctx, &ssm.DescribeInstanceInformationInput{
-		Filters: []ssmTypes.InstanceInformationStringFilter{
-			{Key: aws.String("InstanceIds"), Values: instanceIDs},
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	online := make([]string, 0, len(resp.InstanceInformationList))
-	for _, info := range resp.InstanceInformationList {
-		if info.PingStatus == ssmTypes.PingStatusOnline && info.InstanceId != nil {
-			online = append(online, *info.InstanceId)
+	var online []string
+	for instanceBatch := range slices.Chunk(instanceIDs, ssmMaxInstanceIDs) {
+		var nextToken *string
+		for {
+			resp, err := ssmSvc.DescribeInstanceInformation(ctx, &ssm.DescribeInstanceInformationInput{
+				Filters: []ssmTypes.InstanceInformationStringFilter{
+					{Key: aws.String("InstanceIds"), Values: instanceBatch},
+				},
+				MaxResults: aws.Int32(ssmMaxInstanceIDs),
+				NextToken:  nextToken,
+			})
+			if err != nil {
+				return nil, err
+			}
+			for _, info := range resp.InstanceInformationList {
+				if info.PingStatus == ssmTypes.PingStatusOnline && info.InstanceId != nil {
+					online = append(online, *info.InstanceId)
+				}
+			}
+			if resp.NextToken == nil || *resp.NextToken == "" {
+				break
+			}
+			nextToken = resp.NextToken
 		}
 	}
 	return online, nil
@@ -306,9 +293,8 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 	// SendCommand accepts at most 50 instance IDs per call, so fan out one
 	// command per batch and poll them together.
 	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html
-	const sendCommandMaxTargets = 50
 	var commandIDs []string
-	for batch := range slices.Chunk(onlineIDs, sendCommandMaxTargets) {
+	for batch := range slices.Chunk(onlineIDs, ssmMaxInstanceIDs) {
 		sendOut, err := ssmSvc.SendCommand(ctx, &ssm.SendCommandInput{
 			InstanceIds:  batch,
 			DocumentName: aws.String(documentName),
@@ -404,6 +390,32 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 	return result, firstError
 }
 
+func autoscaleGroupDetails(asg types.AutoScalingGroup) AutoscaleGroupDetails {
+	details := AutoscaleGroupDetails{
+		DesiredCount: int64(*asg.DesiredCapacity),
+		MinSize:      int64(*asg.MinSize),
+		MaxSize:      int64(*asg.MaxSize),
+		InstanceIDs:  make([]string, 0, len(asg.Instances)),
+	}
+
+	for _, instance := range asg.Instances {
+		lifecycleState := string(instance.LifecycleState)
+		if strings.HasPrefix(lifecycleState, "Pending") {
+			details.Pending++
+		}
+		if lifecycleState != "InService" {
+			continue
+		}
+
+		details.ActualCount++
+		if instance.InstanceId != nil {
+			details.InstanceIDs = append(details.InstanceIDs, *instance.InstanceId)
+		}
+	}
+
+	return details
+}
+
 func (a *ASGDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, error) {
 	log.Printf("Collecting AutoScaling details for ASG %q", a.Name)
 
@@ -424,35 +436,7 @@ func (a *ASGDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, error)
 	queryDuration := time.Since(t)
 
 	asg := result.AutoScalingGroups[0]
-
-	var pending int64
-	var running int64
-	for _, instance := range asg.Instances {
-		lifecycleState := string(instance.LifecycleState)
-		if strings.HasPrefix(lifecycleState, "Pending") {
-			pending += 1
-		}
-		// Count instances in InService state
-		if lifecycleState == "InService" {
-			running += 1
-		}
-	}
-
-	instanceIDs := make([]string, 0, len(asg.Instances))
-	for _, instance := range asg.Instances {
-		if instance.InstanceId != nil {
-			instanceIDs = append(instanceIDs, *instance.InstanceId)
-		}
-	}
-
-	details := AutoscaleGroupDetails{
-		Pending:      pending,
-		DesiredCount: int64(*result.AutoScalingGroups[0].DesiredCapacity),
-		MinSize:      int64(*result.AutoScalingGroups[0].MinSize),
-		MaxSize:      int64(*result.AutoScalingGroups[0].MaxSize),
-		InstanceIDs:  instanceIDs,
-		ActualCount:  running,
-	}
+	details := autoscaleGroupDetails(asg)
 
 	log.Printf("↳ Got pending=%d, desired=%d, actual=%d, min=%d, max=%d (took %v)",
 		details.Pending, details.DesiredCount, details.ActualCount, details.MinSize, details.MaxSize, queryDuration)
@@ -536,29 +520,62 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context, findScal
 type dryRunASG struct {
 }
 
-func (a *ASGDriver) SendSIGTERMToAgents(ctx context.Context, instanceID string) error {
-	ec2Client := ec2.NewFromConfig(a.Cfg)
-	ssmClient := ssm.NewFromConfig(a.Cfg)
-
-	// Detect platform - graceful SIGTERM is only supported on Linux
-	descResp, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-		InstanceIds: []string{instanceID},
-	})
-	if err == nil && len(descResp.Reservations) > 0 && len(descResp.Reservations[0].Instances) > 0 {
-		instance := descResp.Reservations[0].Instances[0]
-		if strings.EqualFold(string(instance.Platform), "windows") {
-			return ErrWindowsGracefulScaleInNotSupported
-		}
+// SendSIGTERMToAgentsBatch submits the graceful-stop command for all reachable
+// Linux instances without waiting for command completion. Elastic CI Stack
+// agents self-terminate and decrement desired capacity after draining. The
+// returned count is the number of instances included in accepted commands.
+func (a *ASGDriver) SendSIGTERMToAgentsBatch(ctx context.Context, instanceIDs []string) (int, error) {
+	if len(instanceIDs) == 0 {
+		return 0, nil
 	}
 
-	// Wait for SSM agent to be ready before sending command
-	if err := a.waitForSSMReady(ctx, instanceID, 30*time.Second); err != nil {
-		log.Printf("SSM agent not ready on instance %s, cannot send SIGTERM: %v", instanceID, err)
-		return err
+	platform, err := a.detectPlatform(ctx, ec2.NewFromConfig(a.Cfg), instanceIDs)
+	if err != nil {
+		// The instance owns the capacity decrement on Linux while Windows
+		// needs the SetDesiredCapacity fallback, so guessing the platform
+		// wrong loses the decrement. Fail closed and retry next run.
+		return 0, fmt.Errorf("detect platform for graceful scale-in: %w", err)
 	}
 
-	// With consecutive Lambda invocations the same instance selected for scale-in,
-	// only during the first invocation will actually signal the agent to finish current jobs and stop.
+	return a.sendSIGTERMToAgentsBatch(ctx, ssm.NewFromConfig(a.Cfg), instanceIDs, platform)
+}
+
+// detectPlatform inspects one scale-in candidate to choose the SSM document
+// platform. ASGs are single-platform, so one instance is enough.
+func (a *ASGDriver) detectPlatform(ctx context.Context, client describeInstancesAPI, instanceIDs []string) (string, error) {
+	describeResult, err := describeInstancesTolerant(ctx, client, instanceIDs[:1], a.Name)
+	if err != nil {
+		return "", err
+	}
+	var instances []ec2Types.Instance
+	for _, reservation := range describeResult.Reservations {
+		instances = append(instances, reservation.Instances...)
+	}
+	if len(instances) == 0 {
+		return "", fmt.Errorf("instance %s not found", instanceIDs[0])
+	}
+	return a.getASGPlatform(instances), nil
+}
+
+func (a *ASGDriver) sendSIGTERMToAgentsBatch(ctx context.Context, ssmSvc ssmCheckAPI, instanceIDs []string, platform string) (int, error) {
+	if strings.EqualFold(platform, "windows") {
+		return 0, ErrWindowsGracefulScaleInNotSupported
+	}
+
+	onlineIDs, err := filterOnlineSSMInstances(ctx, ssmSvc, instanceIDs)
+	if err != nil {
+		return 0, fmt.Errorf("describe SSM instance information: %w", err)
+	}
+	if offline := len(instanceIDs) - len(onlineIDs); offline > 0 {
+		log.Printf("[Elastic CI Mode] SSM agent not online for %d of %d graceful scale-in candidate(s); skipping those", offline, len(instanceIDs))
+	}
+	if len(onlineIDs) == 0 {
+		return 0, nil
+	}
+
+	// With consecutive Lambda invocations selecting the same instance, only
+	// the first command stops the agent. Later commands observe the marker and
+	// exit without disrupting the drain already in progress.
 	command := `#!/bin/bash
 if [ -f ` + terminationMarkerPath + ` ]; then
   echo "Already marked for termination, skipping"
@@ -567,21 +584,27 @@ fi
 echo "Termination requested at $(date)" > ` + terminationMarkerPath + `
 sudo systemctl stop buildkite-agent.service || sudo /opt/buildkite-agent/bin/buildkite-agent stop --signal SIGTERM
 `
-	log.Printf("[Elastic CI Mode] Sending SIGTERM to instance %s", instanceID)
 
-	_, err = ssmClient.SendCommand(ctx, &ssm.SendCommandInput{
-		InstanceIds:  []string{instanceID},
-		DocumentName: aws.String("AWS-RunShellScript"),
-		Parameters:   map[string][]string{"commands": {command}},
-		Comment:      aws.String("Gracefully stop Buildkite agent"),
-	})
-
-	if err != nil {
-		log.Printf("[Elastic CI Mode] Error sending SIGTERM to instance %s: %v", instanceID, err)
-		return err
+	var sendErrors []error
+	batchNumber := 0
+	dispatched := 0
+	for instanceBatch := range slices.Chunk(onlineIDs, ssmMaxInstanceIDs) {
+		batchNumber++
+		_, err := ssmSvc.SendCommand(ctx, &ssm.SendCommandInput{
+			InstanceIds:  instanceBatch,
+			DocumentName: aws.String("AWS-RunShellScript"),
+			Parameters:   map[string][]string{"commands": {command}},
+			Comment:      aws.String("Gracefully stop Buildkite agent"),
+		})
+		if err != nil {
+			sendErrors = append(sendErrors, fmt.Errorf("batch %d: %w", batchNumber, err))
+			continue
+		}
+		dispatched += len(instanceBatch)
+		log.Printf("[Elastic CI Mode] Submitted graceful-stop command to %d instance(s)", len(instanceBatch))
 	}
-	log.Printf("[Elastic CI Mode] Successfully sent SIGTERM command to instance %s", instanceID)
-	return nil
+
+	return dispatched, errors.Join(sendErrors...)
 }
 
 // CleanupDanglingInstances finds and marks unhealthy any "zombie" instances where the
@@ -630,7 +653,7 @@ func (a *ASGDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanc
 	}
 
 	// Detect platform from instances (each ASG is single-platform)
-	platform := a.getASGPlatform(ctx, instancesToConsiderChecking)
+	platform := a.getASGPlatform(instancesToConsiderChecking)
 
 	// Sort instances by launch time (oldest first) to prioritize checking older ones
 	sort.SliceStable(instancesToConsiderChecking, func(i, j int) bool {
@@ -739,9 +762,9 @@ func (a *dryRunASG) SetDesiredCapacity(ctx context.Context, count int64) error {
 	return nil
 }
 
-func (a *dryRunASG) SendSIGTERMToAgents(ctx context.Context, instanceID string) error {
-	log.Printf("[DryRun] Would send SIGTERM to instance %s", instanceID)
-	return nil
+func (a *dryRunASG) SendSIGTERMToAgentsBatch(ctx context.Context, instanceIDs []string) (int, error) {
+	log.Printf("[DryRun] Would send SIGTERM to instances %v", instanceIDs)
+	return len(instanceIDs), nil
 }
 
 func (a *dryRunASG) CleanupDanglingInstances(ctx context.Context, minimumInstanceUptime time.Duration, maxDanglingInstancesToCheck int) error {

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -179,6 +179,12 @@ func filterOnlineSSMInstances(ctx context.Context, ssmSvc ssmCheckAPI, instanceI
 	return online, nil
 }
 
+// ssmPollTimings returns how often and for how long to poll Run Command
+// invocations, falling back to the production defaults when unset.
+func (a *ASGDriver) ssmPollTimings() (interval, deadline time.Duration) {
+	return cmp.Or(a.ssmPollInterval, 3*time.Second), cmp.Or(a.ssmPollDeadline, 60*time.Second)
+}
+
 // pollCommandInvocations polls ListCommandInvocations every interval until
 // every expected invocation reaches a terminal status or the deadline elapses.
 // On timeout it returns whatever invocations exist so far. Each poll lists every
@@ -321,8 +327,7 @@ func (a *ASGDriver) checkAndMarkUnhealthy(
 	// first poll, then poll on a fixed interval up to a bounded deadline.
 	// https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetCommandInvocation.html
 	registrationDelay := cmp.Or(a.ssmRegistrationDelay, 3*time.Second)
-	pollInterval := cmp.Or(a.ssmPollInterval, 3*time.Second)
-	pollDeadline := cmp.Or(a.ssmPollDeadline, 60*time.Second)
+	pollInterval, pollDeadline := a.ssmPollTimings()
 	time.Sleep(registrationDelay)
 	results, pollErr := pollCommandInvocations(ctx, ssmSvc, commandIDs, len(onlineIDs), pollInterval, pollDeadline)
 	if pollErr != nil {

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -599,7 +599,7 @@ sudo systemctl stop buildkite-agent.service || sudo /opt/buildkite-agent/bin/bui
 
 	var sendErrors []error
 	batchNumber := 0
-	dispatched := 0
+	accepted := 0
 	for instanceBatch := range slices.Chunk(onlineIDs, ssmMaxInstanceIDs) {
 		batchNumber++
 		_, err := ssmSvc.SendCommand(ctx, &ssm.SendCommandInput{
@@ -607,16 +607,17 @@ sudo systemctl stop buildkite-agent.service || sudo /opt/buildkite-agent/bin/bui
 			DocumentName: aws.String("AWS-RunShellScript"),
 			Parameters:   map[string][]string{"commands": {command}},
 			Comment:      aws.String("Gracefully stop Buildkite agent"),
+			MaxErrors:    aws.String("100%"),
 		})
 		if err != nil {
 			sendErrors = append(sendErrors, fmt.Errorf("batch %d: %w", batchNumber, err))
 			continue
 		}
-		dispatched += len(instanceBatch)
+		accepted += len(instanceBatch)
 		log.Printf("[Elastic CI Mode] Submitted graceful-stop command to %d instance(s)", len(instanceBatch))
 	}
 
-	return dispatched, errors.Join(sendErrors...)
+	return accepted, errors.Join(sendErrors...)
 }
 
 // CleanupDanglingInstances finds and marks unhealthy any "zombie" instances where the

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -44,6 +44,10 @@ type AutoscaleGroupDetails struct {
 	TotalCount   int64    // Total number of instances across all lifecycle states
 }
 
+type scalingActivitiesAPI interface {
+	DescribeScalingActivities(ctx context.Context, params *autoscaling.DescribeScalingActivitiesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeScalingActivitiesOutput, error)
+}
+
 type ASGDriver struct {
 	Name                              string
 	Cfg                               aws.Config
@@ -58,6 +62,9 @@ type ASGDriver struct {
 	ssmRegistrationDelay time.Duration
 	ssmPollInterval      time.Duration
 	ssmPollDeadline      time.Duration
+
+	scalingActivitiesSvc     scalingActivitiesAPI
+	scalingActivitiesTimeout time.Duration
 }
 
 // getASGPlatform detects whether the ASG contains Linux or Windows instances.
@@ -463,11 +470,10 @@ func (a *ASGDriver) SetDesiredCapacity(ctx context.Context, count int64) error {
 	return nil
 }
 
-func (a *ASGDriver) GetAutoscalingActivities(ctx context.Context, nextToken *string) (*autoscaling.DescribeScalingActivitiesOutput, error) {
-	svc := autoscaling.NewFromConfig(a.Cfg)
-	input := &autoscaling.DescribeScalingActivitiesInput{
-		AutoScalingGroupName: aws.String(a.Name),
-		NextToken:            nextToken,
+func (a *ASGDriver) describeScalingActivities(ctx context.Context, input *autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+	svc := a.scalingActivitiesSvc
+	if svc == nil {
+		svc = autoscaling.NewFromConfig(a.Cfg)
 	}
 	return svc.DescribeScalingActivities(ctx, input)
 }
@@ -482,51 +488,69 @@ func isUserRequestedScaleIn(cause string) bool {
 			strings.Contains(cause, userRequestForTerminatingInstance))
 }
 
-func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context, findScaleOut, findScaleIn bool) (*types.Activity, *types.Activity, error) {
+// GetLastScalingInAndOutActivity returns the most recent requested
+// successful scale-out and scale-in activities that started at or after since.
+// A zero since means no lower bound.
+func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context, findScaleOut, findScaleIn bool, since time.Time) (*types.Activity, *types.Activity, error) {
+	if !findScaleOut && !findScaleIn {
+		return nil, nil, nil
+	}
+
 	var nextToken *string
 	var lastScalingOutActivity *types.Activity
 	var lastScalingInActivity *types.Activity
-	hasFoundScalingActivities := false
+	filters := []types.Filter{
+		{Name: aws.String("Status"), Values: []string{activitySucessfulStatusCode}},
+	}
+	if !since.IsZero() {
+		filters = append(filters, types.Filter{
+			Name:   aws.String("StartTimeLowerBound"),
+			Values: []string{since.UTC().Format(time.RFC3339Nano)},
+		})
+	}
 
-	for i := 0; !hasFoundScalingActivities; {
-		i++
-		if a.MaxDescribeScalingActivitiesPages >= 0 && i >= a.MaxDescribeScalingActivitiesPages {
-			return lastScalingOutActivity, lastScalingInActivity, fmt.Errorf("%d exceeds allowed pages for autoscaling:DescribeScalingActivities, %d", i, a.MaxDescribeScalingActivitiesPages)
+	for page := 0; ; page++ {
+		if a.MaxDescribeScalingActivitiesPages > 0 && page >= a.MaxDescribeScalingActivitiesPages {
+			return lastScalingOutActivity, lastScalingInActivity, fmt.Errorf("autoscaling:DescribeScalingActivities exceeded maximum of %d pages", a.MaxDescribeScalingActivitiesPages)
 		}
 
-		output, err := a.GetAutoscalingActivities(ctx, nextToken)
+		output, err := a.describeScalingActivities(ctx, &autoscaling.DescribeScalingActivitiesInput{
+			AutoScalingGroupName: aws.String(a.Name),
+			Filters:              filters,
+			MaxRecords:           aws.Int32(100),
+			NextToken:            nextToken,
+		})
 		if err != nil {
 			return lastScalingOutActivity, lastScalingInActivity, err
 		}
 
-		for _, activity := range output.Activities {
-			cause := aws.ToString(activity.Cause)
-			if string(activity.StatusCode) == activitySucessfulStatusCode {
-				if lastScalingOutActivity == nil &&
-					strings.Contains(cause, userRequestForChangingDesiredCapacity) &&
-					strings.Contains(cause, scalingOutKey) {
-					lastScalingOutActivity = &activity
-				} else if lastScalingInActivity == nil && isUserRequestedScaleIn(cause) {
-					lastScalingInActivity = &activity
-				}
+		for i := range output.Activities {
+			activity := &output.Activities[i]
+			if string(activity.StatusCode) != activitySucessfulStatusCode {
+				continue
 			}
 
-			if findScaleOut && findScaleIn {
-				hasFoundScalingActivities = lastScalingOutActivity != nil && lastScalingInActivity != nil
-			} else if findScaleOut {
-				hasFoundScalingActivities = lastScalingOutActivity != nil
-			} else if findScaleIn {
-				hasFoundScalingActivities = lastScalingInActivity != nil
+			cause := aws.ToString(activity.Cause)
+			if findScaleOut && lastScalingOutActivity == nil &&
+				strings.Contains(cause, userRequestForChangingDesiredCapacity) &&
+				strings.Contains(cause, scalingOutKey) {
+				lastScalingOutActivity = activity
 			}
+			if findScaleIn && lastScalingInActivity == nil && isUserRequestedScaleIn(cause) {
+				lastScalingInActivity = activity
+			}
+		}
+
+		if (!findScaleOut || lastScalingOutActivity != nil) &&
+			(!findScaleIn || lastScalingInActivity != nil) {
+			return lastScalingOutActivity, lastScalingInActivity, nil
 		}
 
 		nextToken = output.NextToken
 		if nextToken == nil {
-			break
+			return lastScalingOutActivity, lastScalingInActivity, nil
 		}
 	}
-
-	return lastScalingOutActivity, lastScalingInActivity, nil
 }
 
 type dryRunASG struct {

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -40,6 +40,7 @@ type AutoscaleGroupDetails struct {
 	MaxSize      int64
 	InstanceIDs  []string // InService instance IDs eligible for scale-in
 	ActualCount  int64    // Actual number of running instances
+	TotalCount   int64    // Total number of instances across all lifecycle states
 }
 
 type ASGDriver struct {
@@ -396,6 +397,7 @@ func autoscaleGroupDetails(asg types.AutoScalingGroup) AutoscaleGroupDetails {
 		MinSize:      int64(*asg.MinSize),
 		MaxSize:      int64(*asg.MaxSize),
 		InstanceIDs:  make([]string, 0, len(asg.Instances)),
+		TotalCount:   int64(len(asg.Instances)),
 	}
 
 	for _, instance := range asg.Instances {

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -587,14 +587,20 @@ func (a *ASGDriver) sendSIGTERMToAgentsBatch(ctx context.Context, ssmSvc ssmChec
 
 	// With consecutive Lambda invocations selecting the same instance, only
 	// the first command stops the agent. Later commands observe the marker and
-	// exit without disrupting the drain already in progress.
+	// exit without disrupting the drain already in progress. The marker is
+	// written before the stop so the drain can see it, and removed again if
+	// both stop commands fail; a stale marker would block every retry.
 	command := `#!/bin/bash
 if [ -f ` + terminationMarkerPath + ` ]; then
   echo "Already marked for termination, skipping"
   exit 0
 fi
 echo "Termination requested at $(date)" > ` + terminationMarkerPath + `
-sudo systemctl stop buildkite-agent.service || sudo /opt/buildkite-agent/bin/buildkite-agent stop --signal SIGTERM
+if ! sudo systemctl stop buildkite-agent.service && ! sudo /opt/buildkite-agent/bin/buildkite-agent stop --signal SIGTERM; then
+  echo "Both stop commands failed, clearing termination marker so a later attempt can retry"
+  rm -f ` + terminationMarkerPath + `
+  exit 1
+fi
 `
 
 	var sendErrors []error

--- a/scaler/asg.go
+++ b/scaler/asg.go
@@ -29,6 +29,7 @@ var ErrWindowsGracefulScaleInNotSupported = errors.New("graceful scale-in not su
 const (
 	activitySucessfulStatusCode           = "Successful"
 	userRequestForChangingDesiredCapacity = "a user request explicitly set group desired capacity changing the desired capacity"
+	userRequestForTerminatingInstance     = "was taken out of service in response to a user request"
 	scalingOutKey                         = "increasing the capacity"
 	shrinkingKey                          = "shrinking the capacity"
 )
@@ -471,9 +472,17 @@ func (a *ASGDriver) GetAutoscalingActivities(ctx context.Context, nextToken *str
 	return svc.DescribeScalingActivities(ctx, input)
 }
 
+// isUserRequestedScaleIn reports whether an activity shrank the group because
+// someone asked for it: a desired-capacity change, or an instance terminated
+// with --should-decrement-desired-capacity, which is how Elastic CI Stack
+// agents leave the group after draining.
+func isUserRequestedScaleIn(cause string) bool {
+	return strings.Contains(cause, shrinkingKey) &&
+		(strings.Contains(cause, userRequestForChangingDesiredCapacity) ||
+			strings.Contains(cause, userRequestForTerminatingInstance))
+}
+
 func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context, findScaleOut, findScaleIn bool) (*types.Activity, *types.Activity, error) {
-	const scalingOutKey = "increasing the capacity"
-	const shrinkingKey = "shrinking the capacity"
 	var nextToken *string
 	var lastScalingOutActivity *types.Activity
 	var lastScalingInActivity *types.Activity
@@ -491,12 +500,13 @@ func (a *ASGDriver) GetLastScalingInAndOutActivity(ctx context.Context, findScal
 		}
 
 		for _, activity := range output.Activities {
-			// Convert StatusCode to string and check if it matches the successful status
-			if string(activity.StatusCode) == activitySucessfulStatusCode &&
-				strings.Contains(*activity.Cause, userRequestForChangingDesiredCapacity) {
-				if lastScalingOutActivity == nil && strings.Contains(*activity.Cause, scalingOutKey) {
+			cause := aws.ToString(activity.Cause)
+			if string(activity.StatusCode) == activitySucessfulStatusCode {
+				if lastScalingOutActivity == nil &&
+					strings.Contains(cause, userRequestForChangingDesiredCapacity) &&
+					strings.Contains(cause, scalingOutKey) {
 					lastScalingOutActivity = &activity
-				} else if lastScalingInActivity == nil && strings.Contains(*activity.Cause, shrinkingKey) {
+				} else if lastScalingInActivity == nil && isUserRequestedScaleIn(cause) {
 					lastScalingInActivity = &activity
 				}
 			}

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -603,6 +603,7 @@ type stubSSMClient struct {
 	sendErr     error
 	sendErrors  []error
 	sendBatches [][]string // InstanceIds passed to each SendCommand call
+	maxErrors   []string
 }
 
 type stubSSMDescribeResponse struct {
@@ -647,6 +648,7 @@ func (s *stubSSMClient) DescribeInstanceInformation(ctx context.Context, params 
 
 func (s *stubSSMClient) SendCommand(ctx context.Context, params *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
 	s.sendBatches = append(s.sendBatches, slices.Clone(params.InstanceIds))
+	s.maxErrors = append(s.maxErrors, aws.ToString(params.MaxErrors))
 	if index := len(s.sendBatches) - 1; index < len(s.sendErrors) && s.sendErrors[index] != nil {
 		return nil, s.sendErrors[index]
 	}
@@ -708,23 +710,29 @@ func TestFilterOnlineSSMInstances(t *testing.T) {
 	}
 }
 
+func onlineSSMOutput(instanceIDs ...string) *ssm.DescribeInstanceInformationOutput {
+	output := &ssm.DescribeInstanceInformationOutput{}
+	for _, instanceID := range instanceIDs {
+		output.InstanceInformationList = append(output.InstanceInformationList, ssmTypes.InstanceInformation{
+			InstanceId: aws.String(instanceID),
+			PingStatus: ssmTypes.PingStatusOnline,
+		})
+	}
+	return output
+}
+
 func TestFilterOnlineSSMInstancesChunksAndPaginates(t *testing.T) {
 	instanceIDs := make([]string, 51)
 	for i := range instanceIDs {
 		instanceIDs[i] = fmt.Sprintf("i-%03d", i)
 	}
+	firstPage := onlineSSMOutput("i-000")
+	firstPage.NextToken = aws.String("page-2")
 	stub := &stubSSMClient{
 		describeResponses: []stubSSMDescribeResponse{
-			{out: &ssm.DescribeInstanceInformationOutput{
-				InstanceInformationList: []ssmTypes.InstanceInformation{{InstanceId: aws.String("i-000"), PingStatus: ssmTypes.PingStatusOnline}},
-				NextToken:               aws.String("page-2"),
-			}},
-			{out: &ssm.DescribeInstanceInformationOutput{
-				InstanceInformationList: []ssmTypes.InstanceInformation{{InstanceId: aws.String("i-001"), PingStatus: ssmTypes.PingStatusOnline}},
-			}},
-			{out: &ssm.DescribeInstanceInformationOutput{
-				InstanceInformationList: []ssmTypes.InstanceInformation{{InstanceId: aws.String("i-050"), PingStatus: ssmTypes.PingStatusOnline}},
-			}},
+			{out: firstPage},
+			{out: onlineSSMOutput("i-001")},
+			{out: onlineSSMOutput("i-050")},
 		},
 	}
 
@@ -750,30 +758,20 @@ func TestFilterOnlineSSMInstancesChunksAndPaginates(t *testing.T) {
 }
 
 func TestSendSIGTERMToAgentsBatch(t *testing.T) {
-	onlineOutput := func(instanceIDs ...string) *ssm.DescribeInstanceInformationOutput {
-		output := &ssm.DescribeInstanceInformationOutput{}
-		for _, instanceID := range instanceIDs {
-			output.InstanceInformationList = append(output.InstanceInformationList, ssmTypes.InstanceInformation{
-				InstanceId: aws.String(instanceID),
-				PingStatus: ssmTypes.PingStatusOnline,
-			})
-		}
-		return output
+	instanceIDs := make([]string, 120)
+	for i := range instanceIDs {
+		instanceIDs[i] = fmt.Sprintf("i-%03d", i)
 	}
 
 	t.Run("chunks more than 50 targets without polling completion", func(t *testing.T) {
-		instanceIDs := make([]string, 120)
-		for i := range instanceIDs {
-			instanceIDs[i] = fmt.Sprintf("i-%03d", i)
-		}
-		stub := &stubSSMClient{describeOut: onlineOutput(instanceIDs...)}
+		stub := &stubSSMClient{describeOut: onlineSSMOutput(instanceIDs...)}
 
-		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, instanceIDs, "linux")
+		accepted, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, instanceIDs, "linux")
 		if err != nil {
 			t.Fatalf("sendSIGTERMToAgentsBatch() error = %v", err)
 		}
-		if dispatched != 120 {
-			t.Errorf("dispatched instances = %d, want 120", dispatched)
+		if accepted != 120 {
+			t.Errorf("accepted instances = %d, want 120", accepted)
 		}
 		gotBatchSizes := make([]int, len(stub.sendBatches))
 		for i, batch := range stub.sendBatches {
@@ -782,59 +780,43 @@ func TestSendSIGTERMToAgentsBatch(t *testing.T) {
 		if want := []int{50, 50, 20}; !slices.Equal(gotBatchSizes, want) {
 			t.Errorf("SendCommand batch sizes = %v, want %v", gotBatchSizes, want)
 		}
+		if want := []string{"100%", "100%", "100%"}; !slices.Equal(stub.maxErrors, want) {
+			t.Errorf("SendCommand MaxErrors = %v, want %v", stub.maxErrors, want)
+		}
 		if stub.listCalls != 0 {
 			t.Errorf("ListCommandInvocations calls = %d, want 0", stub.listCalls)
 		}
 	})
 
 	t.Run("skips targets whose SSM agent is offline", func(t *testing.T) {
-		stub := &stubSSMClient{describeOut: onlineOutput("i-a", "i-c")}
+		stub := &stubSSMClient{describeOut: onlineSSMOutput("i-a", "i-c")}
 
-		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-a", "i-b", "i-c"}, "linux")
+		accepted, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-a", "i-b", "i-c"}, "linux")
 		if err != nil {
 			t.Fatalf("sendSIGTERMToAgentsBatch() error = %v", err)
 		}
-		if dispatched != 2 {
-			t.Errorf("dispatched instances = %d, want 2", dispatched)
+		if accepted != 2 {
+			t.Errorf("accepted instances = %d, want 2", accepted)
 		}
 		if len(stub.sendBatches) != 1 || !slices.Equal(stub.sendBatches[0], []string{"i-a", "i-c"}) {
 			t.Errorf("SendCommand targets = %v, want [[i-a i-c]]", stub.sendBatches)
 		}
 	})
 
-	t.Run("reports no dispatch when every SSM agent is offline", func(t *testing.T) {
-		stub := &stubSSMClient{}
-
-		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-a", "i-b"}, "linux")
-		if err != nil {
-			t.Fatalf("sendSIGTERMToAgentsBatch() error = %v", err)
-		}
-		if dispatched != 0 {
-			t.Errorf("dispatched instances = %d, want 0", dispatched)
-		}
-		if len(stub.sendBatches) != 0 {
-			t.Errorf("SendCommand calls = %d, want 0", len(stub.sendBatches))
-		}
-	})
-
 	t.Run("attempts later batches after partial failures", func(t *testing.T) {
-		instanceIDs := make([]string, 120)
-		for i := range instanceIDs {
-			instanceIDs[i] = fmt.Sprintf("i-%03d", i)
-		}
 		firstErr := errors.New("first batch failed")
 		lastErr := errors.New("last batch failed")
 		stub := &stubSSMClient{
-			describeOut: onlineOutput(instanceIDs...),
+			describeOut: onlineSSMOutput(instanceIDs...),
 			sendErrors:  []error{firstErr, nil, lastErr},
 		}
 
-		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, instanceIDs, "linux")
+		accepted, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, instanceIDs, "linux")
 		if !errors.Is(err, firstErr) || !errors.Is(err, lastErr) {
 			t.Errorf("sendSIGTERMToAgentsBatch() error = %v, want both batch errors", err)
 		}
-		if dispatched != 50 {
-			t.Errorf("dispatched instances = %d, want 50", dispatched)
+		if accepted != 50 {
+			t.Errorf("accepted instances = %d, want 50", accepted)
 		}
 		if got, want := len(stub.sendBatches), 3; got != want {
 			t.Errorf("SendCommand calls = %d, want %d", got, want)
@@ -844,12 +826,12 @@ func TestSendSIGTERMToAgentsBatch(t *testing.T) {
 	t.Run("rejects Windows before contacting SSM", func(t *testing.T) {
 		stub := &stubSSMClient{}
 
-		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-windows"}, "windows")
+		accepted, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-windows"}, "windows")
 		if !errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
 			t.Errorf("sendSIGTERMToAgentsBatch() error = %v, want %v", err, ErrWindowsGracefulScaleInNotSupported)
 		}
-		if dispatched != 0 {
-			t.Errorf("dispatched instances = %d, want 0", dispatched)
+		if accepted != 0 {
+			t.Errorf("accepted instances = %d, want 0", accepted)
 		}
 		if len(stub.describeCalls) != 0 || len(stub.sendBatches) != 0 {
 			t.Errorf("SSM calls made for Windows: describe=%d send=%d, want none", len(stub.describeCalls), len(stub.sendBatches))

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -23,6 +23,217 @@ import (
 	"github.com/aws/smithy-go"
 )
 
+type stubScalingActivitiesClient struct {
+	calls     []autoscaling.DescribeScalingActivitiesInput
+	responses []stubScalingActivitiesResponse
+	describe  func(context.Context, *autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error)
+}
+
+type stubScalingActivitiesResponse struct {
+	output *autoscaling.DescribeScalingActivitiesOutput
+	err    error
+}
+
+func (s *stubScalingActivitiesClient) DescribeScalingActivities(ctx context.Context, params *autoscaling.DescribeScalingActivitiesInput, optFns ...func(*autoscaling.Options)) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+	s.calls = append(s.calls, *params)
+	if s.describe != nil {
+		return s.describe(ctx, params)
+	}
+	response := s.responses[len(s.calls)-1]
+	return response.output, response.err
+}
+
+func TestGetLastScalingInAndOutActivity(t *testing.T) {
+	since := time.Date(2026, time.August, 26, 16, 0, 0, 0, time.FixedZone("UTC+2", 2*60*60))
+	scaleOut := types.Activity{
+		ActivityId: aws.String("scale-out"),
+		Cause:      aws.String("a user request explicitly set group desired capacity changing the desired capacity from 2 to 3, increasing the capacity"),
+		StatusCode: types.ScalingActivityStatusCodeSuccessful,
+	}
+	scaleIn := types.Activity{
+		ActivityId: aws.String("scale-in"),
+		Cause:      aws.String("At 2026-08-26T16:14:36Z instance i-017bacd33066f0408 was taken out of service in response to a user request, shrinking the capacity from 13 to 12."),
+		StatusCode: types.ScalingActivityStatusCodeSuccessful,
+	}
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{{
+			output: &autoscaling.DescribeScalingActivitiesOutput{
+				Activities: []types.Activity{
+					{Cause: aws.String("shrinking the capacity"), StatusCode: types.ScalingActivityStatusCodeFailed},
+					{StatusCode: types.ScalingActivityStatusCodeSuccessful},
+					scaleOut,
+					scaleIn,
+				},
+			},
+		}},
+	}
+	driver := &ASGDriver{
+		Name:                              "agents",
+		MaxDescribeScalingActivitiesPages: -1,
+		scalingActivitiesSvc:              client,
+	}
+
+	gotScaleOut, gotScaleIn, err := driver.GetLastScalingInAndOutActivity(t.Context(), true, true, since)
+	if err != nil {
+		t.Fatalf("GetLastScalingInAndOutActivity() error = %v", err)
+	}
+	if gotScaleOut == nil || aws.ToString(gotScaleOut.ActivityId) != "scale-out" {
+		t.Errorf("scale-out activity = %#v, want %q", gotScaleOut, "scale-out")
+	}
+	if gotScaleIn == nil || aws.ToString(gotScaleIn.ActivityId) != "scale-in" {
+		t.Errorf("scale-in activity = %#v, want %q", gotScaleIn, "scale-in")
+	}
+	if len(client.calls) != 1 {
+		t.Fatalf("DescribeScalingActivities calls = %d, want 1", len(client.calls))
+	}
+
+	input := client.calls[0]
+	if got := aws.ToString(input.AutoScalingGroupName); got != "agents" {
+		t.Errorf("AutoScalingGroupName = %q, want %q", got, "agents")
+	}
+	if got := aws.ToInt32(input.MaxRecords); got != 100 {
+		t.Errorf("MaxRecords = %d, want 100", got)
+	}
+	filterValues := make(map[string][]string, len(input.Filters))
+	for _, filter := range input.Filters {
+		filterValues[aws.ToString(filter.Name)] = filter.Values
+	}
+	if got, want := filterValues["Status"], []string{activitySucessfulStatusCode}; !slices.Equal(got, want) {
+		t.Errorf("Status filter = %v, want %v", got, want)
+	}
+	if got, want := filterValues["StartTimeLowerBound"], []string{since.UTC().Format(time.RFC3339Nano)}; !slices.Equal(got, want) {
+		t.Errorf("StartTimeLowerBound filter = %v, want %v", got, want)
+	}
+}
+
+func TestGetLastScalingInAndOutActivityPagination(t *testing.T) {
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{
+			{
+				output: &autoscaling.DescribeScalingActivitiesOutput{
+					NextToken: aws.String("next"),
+				},
+			},
+			{
+				output: &autoscaling.DescribeScalingActivitiesOutput{
+					Activities: []types.Activity{{
+						ActivityId: aws.String("scale-in"),
+						Cause:      aws.String("At 2026-08-26T16:14:36Z instance i-017bacd33066f0408 was taken out of service in response to a user request, shrinking the capacity from 2 to 1."),
+						StatusCode: types.ScalingActivityStatusCodeSuccessful,
+					}},
+				},
+			},
+		},
+	}
+	driver := &ASGDriver{
+		MaxDescribeScalingActivitiesPages: 2,
+		scalingActivitiesSvc:              client,
+	}
+
+	_, gotScaleIn, err := driver.GetLastScalingInAndOutActivity(t.Context(), false, true, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetLastScalingInAndOutActivity() error = %v", err)
+	}
+	if gotScaleIn == nil || aws.ToString(gotScaleIn.ActivityId) != "scale-in" {
+		t.Errorf("scale-in activity = %#v, want %q", gotScaleIn, "scale-in")
+	}
+	if len(client.calls) != 2 {
+		t.Errorf("DescribeScalingActivities calls = %d, want 2", len(client.calls))
+	}
+	if got := aws.ToString(client.calls[1].NextToken); got != "next" {
+		t.Errorf("second NextToken = %q, want %q", got, "next")
+	}
+}
+
+func TestGetLastScalingInAndOutActivityZeroPageLimitIsUnlimited(t *testing.T) {
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{
+			{
+				output: &autoscaling.DescribeScalingActivitiesOutput{
+					NextToken: aws.String("next"),
+				},
+			},
+			{
+				output: &autoscaling.DescribeScalingActivitiesOutput{
+					Activities: []types.Activity{{
+						ActivityId: aws.String("scale-in"),
+						Cause:      aws.String("At 2026-08-26T16:14:36Z instance i-017bacd33066f0408 was taken out of service in response to a user request, shrinking the capacity from 2 to 1."),
+						StatusCode: types.ScalingActivityStatusCodeSuccessful,
+					}},
+				},
+			},
+		},
+	}
+	driver := &ASGDriver{scalingActivitiesSvc: client}
+
+	_, gotScaleIn, err := driver.GetLastScalingInAndOutActivity(t.Context(), false, true, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetLastScalingInAndOutActivity() error = %v", err)
+	}
+	if gotScaleIn == nil || aws.ToString(gotScaleIn.ActivityId) != "scale-in" {
+		t.Errorf("scale-in activity = %#v, want %q", gotScaleIn, "scale-in")
+	}
+	if got, want := len(client.calls), 2; got != want {
+		t.Errorf("DescribeScalingActivities calls = %d, want %d", got, want)
+	}
+}
+
+func TestGetLastScalingInAndOutActivityCompleteWithoutMatch(t *testing.T) {
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{{
+			output: &autoscaling.DescribeScalingActivitiesOutput{},
+		}},
+	}
+	driver := &ASGDriver{
+		MaxDescribeScalingActivitiesPages: -1,
+		scalingActivitiesSvc:              client,
+	}
+
+	_, gotScaleIn, err := driver.GetLastScalingInAndOutActivity(t.Context(), false, true, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetLastScalingInAndOutActivity() error = %v", err)
+	}
+	if gotScaleIn != nil {
+		t.Errorf("scale-in activity = %#v, want nil", gotScaleIn)
+	}
+}
+
+func TestGetLastScalingInAndOutActivityFailsWhenPageLimitIsIncomplete(t *testing.T) {
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{{
+			output: &autoscaling.DescribeScalingActivitiesOutput{NextToken: aws.String("next")},
+		}},
+	}
+	driver := &ASGDriver{
+		MaxDescribeScalingActivitiesPages: 1,
+		scalingActivitiesSvc:              client,
+	}
+
+	_, _, err := driver.GetLastScalingInAndOutActivity(t.Context(), false, true, time.Now().Add(-time.Hour))
+	if err == nil {
+		t.Fatal("GetLastScalingInAndOutActivity() error = nil, want page-limit error")
+	}
+	if len(client.calls) != 1 {
+		t.Errorf("DescribeScalingActivities calls = %d, want 1", len(client.calls))
+	}
+}
+
+func TestGetLastScalingInAndOutActivityPropagatesAPIErrors(t *testing.T) {
+	wantErr := errors.New("describe activities")
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{{err: wantErr}},
+	}
+	driver := &ASGDriver{
+		MaxDescribeScalingActivitiesPages: -1,
+		scalingActivitiesSvc:              client,
+	}
+
+	_, _, err := driver.GetLastScalingInAndOutActivity(t.Context(), false, true, time.Now().Add(-time.Hour))
+	if !errors.Is(err, wantErr) {
+		t.Errorf("GetLastScalingInAndOutActivity() error = %v, want %v", err, wantErr)
+	}
+}
+
 func TestGetASGPlatform(t *testing.T) {
 	driver := &ASGDriver{}
 

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -113,6 +113,49 @@ func TestAutoscaleGroupDetailsUsesOnlyInServiceInstancesAsCandidates(t *testing.
 	}
 }
 
+func TestIsUserRequestedScaleIn(t *testing.T) {
+	testCases := []struct {
+		name  string
+		cause string
+		want  bool
+	}{
+		{
+			name:  "desired capacity change",
+			cause: "At 2026-09-02T08:00:00Z a user request explicitly set group desired capacity changing the desired capacity from 4 to 3.  At 2026-09-02T08:00:30Z an instance was taken out of service in response to a difference between desired and actual capacity, shrinking the capacity from 4 to 3.  At 2026-09-02T08:00:31Z instance i-0123456789abcdef0 was selected for termination.",
+			want:  true,
+		},
+		{
+			name:  "instance terminates with decrement",
+			cause: "At 2026-09-02T08:00:00Z instance i-0123456789abcdef0 was taken out of service in response to a user request, shrinking the capacity from 4 to 3.",
+			want:  true,
+		},
+		{
+			name:  "desired capacity change scaling out",
+			cause: "At 2026-09-02T08:00:00Z a user request explicitly set group desired capacity changing the desired capacity from 3 to 4.  At 2026-09-02T08:00:30Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 3 to 4.",
+		},
+		{
+			name:  "instance termination without decrement",
+			cause: "At 2026-09-02T08:00:00Z instance i-0123456789abcdef0 was taken out of service in response to a user request.",
+		},
+		{
+			name:  "unhealthy instance replaced",
+			cause: "At 2026-09-02T08:00:00Z an instance was taken out of service in response to an EC2 health check indicating it has been terminated or stopped.",
+		},
+		{
+			name:  "alarm-driven scale-in",
+			cause: "At 2026-09-02T08:00:00Z a monitor alarm in state ALARM triggered policy changing the desired capacity from 4 to 3.  At 2026-09-02T08:00:30Z an instance was taken out of service in response to a difference between desired and actual capacity, shrinking the capacity from 4 to 3.",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUserRequestedScaleIn(tc.cause); got != tc.want {
+				t.Errorf("isUserRequestedScaleIn(%q) = %t, want %t", tc.cause, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestParseStaleInstanceIDs(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -105,6 +105,9 @@ func TestAutoscaleGroupDetailsUsesOnlyInServiceInstancesAsCandidates(t *testing.
 	if got, want := details.ActualCount, int64(1); got != want {
 		t.Errorf("actual count = %d, want %d", got, want)
 	}
+	if got, want := details.TotalCount, int64(5); got != want {
+		t.Errorf("total count = %d, want %d", got, want)
+	}
 	if got, want := details.InstanceIDs, []string{"i-in-service"}; !slices.Equal(got, want) {
 		t.Errorf("scale-in candidates = %v, want %v", got, want)
 	}
@@ -282,16 +285,13 @@ func TestDescribeInstancesTolerant(t *testing.T) {
 }
 
 func TestDetectPlatform(t *testing.T) {
-	ctx := context.Background()
 	driver := &ASGDriver{Name: "asg-1"}
 	describeErr := errors.New("describe failed")
 
-	reservations := func(platforms ...ec2Types.PlatformValues) []ec2Types.Reservation {
-		var instances []ec2Types.Instance
-		for _, p := range platforms {
-			instances = append(instances, ec2Types.Instance{Platform: p})
-		}
-		return []ec2Types.Reservation{{Instances: instances}}
+	platformResponse := func(platform ec2Types.PlatformValues) stubDescribeResponse {
+		return stubDescribeResponse{out: &ec2.DescribeInstancesOutput{
+			Reservations: []ec2Types.Reservation{{Instances: []ec2Types.Instance{{Platform: platform}}}},
+		}}
 	}
 
 	tests := []struct {
@@ -300,35 +300,17 @@ func TestDetectPlatform(t *testing.T) {
 		wantPlatform string
 		wantErr      bool
 	}{
-		{
-			name:         "linux instance",
-			response:     stubDescribeResponse{out: &ec2.DescribeInstancesOutput{Reservations: reservations("")}},
-			wantPlatform: "linux",
-		},
-		{
-			name:         "windows instance",
-			response:     stubDescribeResponse{out: &ec2.DescribeInstancesOutput{Reservations: reservations("windows")}},
-			wantPlatform: "windows",
-		},
-		{
-			name:     "describe error fails closed",
-			response: stubDescribeResponse{err: describeErr},
-			wantErr:  true,
-		},
-		{
-			// The sampled candidate can disappear between candidate selection
-			// and the describe call. Guessing Linux for a Windows ASG here
-			// would skip the SetDesiredCapacity fallback, so fail closed.
-			name:     "missing instance fails closed",
-			response: stubDescribeResponse{out: &ec2.DescribeInstancesOutput{}},
-			wantErr:  true,
-		},
+		{name: "linux instance", response: platformResponse(""), wantPlatform: "linux"},
+		{name: "windows instance", response: platformResponse("windows"), wantPlatform: "windows"},
+		{name: "describe error fails closed", response: stubDescribeResponse{err: describeErr}, wantErr: true},
+		// Missing candidates must fail closed: guessing Linux for a Windows ASG skips the capacity fallback.
+		{name: "missing instance fails closed", response: stubDescribeResponse{out: &ec2.DescribeInstancesOutput{}}, wantErr: true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			stub := &stubDescribeInstancesClient{responses: []stubDescribeResponse{tc.response}}
-			platform, err := driver.detectPlatform(ctx, stub, []string{"i-a", "i-b"})
+			platform, err := driver.detectPlatform(t.Context(), stub, []string{"i-a", "i-b"})
 			if tc.wantErr {
 				if err == nil {
 					t.Fatal("detectPlatform() error = nil, want error")

--- a/scaler/asg_test.go
+++ b/scaler/asg_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -24,7 +25,6 @@ import (
 
 func TestGetASGPlatform(t *testing.T) {
 	driver := &ASGDriver{}
-	ctx := context.Background()
 
 	testCases := []struct {
 		name             string
@@ -77,11 +77,36 @@ func TestGetASGPlatform(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			platform := driver.getASGPlatform(ctx, tc.instances)
+			platform := driver.getASGPlatform(tc.instances)
 			if platform != tc.expectedPlatform {
 				t.Errorf("expected platform %q, got %q", tc.expectedPlatform, platform)
 			}
 		})
+	}
+}
+
+func TestAutoscaleGroupDetailsUsesOnlyInServiceInstancesAsCandidates(t *testing.T) {
+	details := autoscaleGroupDetails(types.AutoScalingGroup{
+		DesiredCapacity: aws.Int32(4),
+		MinSize:         aws.Int32(1),
+		MaxSize:         aws.Int32(10),
+		Instances: []types.Instance{
+			{InstanceId: aws.String("i-pending"), LifecycleState: types.LifecycleStatePending},
+			{InstanceId: aws.String("i-pending-wait"), LifecycleState: types.LifecycleStatePendingWait},
+			{InstanceId: aws.String("i-in-service"), LifecycleState: types.LifecycleStateInService},
+			{InstanceId: aws.String("i-terminating"), LifecycleState: types.LifecycleStateTerminating},
+			{InstanceId: aws.String("i-standby"), LifecycleState: types.LifecycleStateStandby},
+		},
+	})
+
+	if got, want := details.Pending, int64(2); got != want {
+		t.Errorf("pending count = %d, want %d", got, want)
+	}
+	if got, want := details.ActualCount, int64(1); got != want {
+		t.Errorf("actual count = %d, want %d", got, want)
+	}
+	if got, want := details.InstanceIDs, []string{"i-in-service"}; !slices.Equal(got, want) {
+		t.Errorf("scale-in candidates = %v, want %v", got, want)
 	}
 }
 
@@ -256,6 +281,73 @@ func TestDescribeInstancesTolerant(t *testing.T) {
 	})
 }
 
+func TestDetectPlatform(t *testing.T) {
+	ctx := context.Background()
+	driver := &ASGDriver{Name: "asg-1"}
+	describeErr := errors.New("describe failed")
+
+	reservations := func(platforms ...ec2Types.PlatformValues) []ec2Types.Reservation {
+		var instances []ec2Types.Instance
+		for _, p := range platforms {
+			instances = append(instances, ec2Types.Instance{Platform: p})
+		}
+		return []ec2Types.Reservation{{Instances: instances}}
+	}
+
+	tests := []struct {
+		name         string
+		response     stubDescribeResponse
+		wantPlatform string
+		wantErr      bool
+	}{
+		{
+			name:         "linux instance",
+			response:     stubDescribeResponse{out: &ec2.DescribeInstancesOutput{Reservations: reservations("")}},
+			wantPlatform: "linux",
+		},
+		{
+			name:         "windows instance",
+			response:     stubDescribeResponse{out: &ec2.DescribeInstancesOutput{Reservations: reservations("windows")}},
+			wantPlatform: "windows",
+		},
+		{
+			name:     "describe error fails closed",
+			response: stubDescribeResponse{err: describeErr},
+			wantErr:  true,
+		},
+		{
+			// The sampled candidate can disappear between candidate selection
+			// and the describe call. Guessing Linux for a Windows ASG here
+			// would skip the SetDesiredCapacity fallback, so fail closed.
+			name:     "missing instance fails closed",
+			response: stubDescribeResponse{out: &ec2.DescribeInstancesOutput{}},
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubDescribeInstancesClient{responses: []stubDescribeResponse{tc.response}}
+			platform, err := driver.detectPlatform(ctx, stub, []string{"i-a", "i-b"})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("detectPlatform() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("detectPlatform() error = %v", err)
+			}
+			if platform != tc.wantPlatform {
+				t.Errorf("detectPlatform() = %q, want %q", platform, tc.wantPlatform)
+			}
+			if got := stub.calls[0].InstanceIds; !slices.Equal(got, []string{"i-a"}) {
+				t.Errorf("described %v, want only the first candidate", got)
+			}
+		})
+	}
+}
+
 func TestGetCheckCommand(t *testing.T) {
 	driver := &ASGDriver{}
 
@@ -346,6 +438,12 @@ printf 'ActiveState=%s\nMainPID=%s\n' "$ACTIVE_STATE" "$MAIN_PID"
 		// The normal graceful scale-in window: marker written, systemd
 		// stopping the unit, agent finishing its last job.
 		{name: "deactivating with marker", activeState: "deactivating", mainPID: "123", marker: true, want: "DRAINING: ActiveState=deactivating MainPID=123"},
+		// After the agent exits, ExecStopPost (the stack's terminate-instance
+		// script) runs with MainPID=0 while the unit stays deactivating. The
+		// instance is about to decrement desired capacity and terminate
+		// itself, so marking it unhealthy here would race that handoff.
+		{name: "deactivating in ExecStopPost with marker", activeState: "deactivating", mainPID: "0", marker: true, want: "DRAINING: ActiveState=deactivating MainPID=0"},
+		{name: "deactivating in ExecStopPost without marker", activeState: "deactivating", mainPID: "0", want: "RUNNING"},
 		{name: "failed unit", activeState: "failed", mainPID: "0", want: "NOT_RUNNING: ActiveState=failed"},
 		// Type=simple assumption: active with MainPID=0 means the process is
 		// gone even though systemd still reports the unit active.
@@ -466,15 +564,25 @@ func makeInstancesForRotation(n int) []ec2Types.Instance {
 // stubSSMClient implements ssmCheckAPI for unit tests. Each
 // ListCommandInvocations call returns the next listResponses entry, or repeats
 // the last one if exhausted (so deadline-driven tests don't have to enumerate
-// every poll).
+// every poll). DescribeInstanceInformation resolves in priority order:
+// describeResponses (one entry per call), then describeErr, then describeOut
+// filtered down to the instance IDs requested in that call.
 type stubSSMClient struct {
-	describeOut   *ssm.DescribeInstanceInformationOutput
-	describeErr   error
-	listResponses []stubListResponse
-	listCalls     int
+	describeOut       *ssm.DescribeInstanceInformationOutput
+	describeErr       error
+	describeResponses []stubSSMDescribeResponse
+	describeCalls     []ssm.DescribeInstanceInformationInput
+	listResponses     []stubListResponse
+	listCalls         int
 
 	sendErr     error
+	sendErrors  []error
 	sendBatches [][]string // InstanceIds passed to each SendCommand call
+}
+
+type stubSSMDescribeResponse struct {
+	out *ssm.DescribeInstanceInformationOutput
+	err error
 }
 
 type stubListResponse struct {
@@ -483,11 +591,40 @@ type stubListResponse struct {
 }
 
 func (s *stubSSMClient) DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, _ ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error) {
-	return s.describeOut, s.describeErr
+	s.describeCalls = append(s.describeCalls, *params)
+	if len(s.describeResponses) > 0 {
+		response := s.describeResponses[len(s.describeCalls)-1]
+		return response.out, response.err
+	}
+	if s.describeErr != nil {
+		return nil, s.describeErr
+	}
+	if s.describeOut == nil {
+		return &ssm.DescribeInstanceInformationOutput{}, nil
+	}
+
+	requested := make(map[string]bool)
+	for _, filter := range params.Filters {
+		if aws.ToString(filter.Key) == "InstanceIds" {
+			for _, instanceID := range filter.Values {
+				requested[instanceID] = true
+			}
+		}
+	}
+	output := &ssm.DescribeInstanceInformationOutput{}
+	for _, info := range s.describeOut.InstanceInformationList {
+		if requested[aws.ToString(info.InstanceId)] {
+			output.InstanceInformationList = append(output.InstanceInformationList, info)
+		}
+	}
+	return output, nil
 }
 
 func (s *stubSSMClient) SendCommand(ctx context.Context, params *ssm.SendCommandInput, _ ...func(*ssm.Options)) (*ssm.SendCommandOutput, error) {
-	s.sendBatches = append(s.sendBatches, params.InstanceIds)
+	s.sendBatches = append(s.sendBatches, slices.Clone(params.InstanceIds))
+	if index := len(s.sendBatches) - 1; index < len(s.sendErrors) && s.sendErrors[index] != nil {
+		return nil, s.sendErrors[index]
+	}
 	if s.sendErr != nil {
 		return nil, s.sendErr
 	}
@@ -541,6 +678,158 @@ func TestFilterOnlineSSMInstances(t *testing.T) {
 	if !slices.Equal(got, []string{"i-a", "i-c"}) {
 		t.Errorf("got %v, want [i-a i-c]", got)
 	}
+	if got := aws.ToInt32(stub.describeCalls[0].MaxResults); got != ssmMaxInstanceIDs {
+		t.Errorf("MaxResults = %d, want %d", got, ssmMaxInstanceIDs)
+	}
+}
+
+func TestFilterOnlineSSMInstancesChunksAndPaginates(t *testing.T) {
+	instanceIDs := make([]string, 51)
+	for i := range instanceIDs {
+		instanceIDs[i] = fmt.Sprintf("i-%03d", i)
+	}
+	stub := &stubSSMClient{
+		describeResponses: []stubSSMDescribeResponse{
+			{out: &ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmTypes.InstanceInformation{{InstanceId: aws.String("i-000"), PingStatus: ssmTypes.PingStatusOnline}},
+				NextToken:               aws.String("page-2"),
+			}},
+			{out: &ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmTypes.InstanceInformation{{InstanceId: aws.String("i-001"), PingStatus: ssmTypes.PingStatusOnline}},
+			}},
+			{out: &ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmTypes.InstanceInformation{{InstanceId: aws.String("i-050"), PingStatus: ssmTypes.PingStatusOnline}},
+			}},
+		},
+	}
+
+	got, err := filterOnlineSSMInstances(t.Context(), stub, instanceIDs)
+	if err != nil {
+		t.Fatalf("filterOnlineSSMInstances() error = %v", err)
+	}
+	if want := []string{"i-000", "i-001", "i-050"}; !slices.Equal(got, want) {
+		t.Errorf("online instances = %v, want %v", got, want)
+	}
+	if got, want := len(stub.describeCalls), 3; got != want {
+		t.Fatalf("DescribeInstanceInformation calls = %d, want %d", got, want)
+	}
+	if got, want := len(stub.describeCalls[0].Filters[0].Values), ssmMaxInstanceIDs; got != want {
+		t.Errorf("first instance filter size = %d, want %d", got, want)
+	}
+	if got, want := aws.ToString(stub.describeCalls[1].NextToken), "page-2"; got != want {
+		t.Errorf("second NextToken = %q, want %q", got, want)
+	}
+	if got, want := len(stub.describeCalls[2].Filters[0].Values), 1; got != want {
+		t.Errorf("last instance filter size = %d, want %d", got, want)
+	}
+}
+
+func TestSendSIGTERMToAgentsBatch(t *testing.T) {
+	onlineOutput := func(instanceIDs ...string) *ssm.DescribeInstanceInformationOutput {
+		output := &ssm.DescribeInstanceInformationOutput{}
+		for _, instanceID := range instanceIDs {
+			output.InstanceInformationList = append(output.InstanceInformationList, ssmTypes.InstanceInformation{
+				InstanceId: aws.String(instanceID),
+				PingStatus: ssmTypes.PingStatusOnline,
+			})
+		}
+		return output
+	}
+
+	t.Run("chunks more than 50 targets without polling completion", func(t *testing.T) {
+		instanceIDs := make([]string, 120)
+		for i := range instanceIDs {
+			instanceIDs[i] = fmt.Sprintf("i-%03d", i)
+		}
+		stub := &stubSSMClient{describeOut: onlineOutput(instanceIDs...)}
+
+		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, instanceIDs, "linux")
+		if err != nil {
+			t.Fatalf("sendSIGTERMToAgentsBatch() error = %v", err)
+		}
+		if dispatched != 120 {
+			t.Errorf("dispatched instances = %d, want 120", dispatched)
+		}
+		gotBatchSizes := make([]int, len(stub.sendBatches))
+		for i, batch := range stub.sendBatches {
+			gotBatchSizes[i] = len(batch)
+		}
+		if want := []int{50, 50, 20}; !slices.Equal(gotBatchSizes, want) {
+			t.Errorf("SendCommand batch sizes = %v, want %v", gotBatchSizes, want)
+		}
+		if stub.listCalls != 0 {
+			t.Errorf("ListCommandInvocations calls = %d, want 0", stub.listCalls)
+		}
+	})
+
+	t.Run("skips targets whose SSM agent is offline", func(t *testing.T) {
+		stub := &stubSSMClient{describeOut: onlineOutput("i-a", "i-c")}
+
+		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-a", "i-b", "i-c"}, "linux")
+		if err != nil {
+			t.Fatalf("sendSIGTERMToAgentsBatch() error = %v", err)
+		}
+		if dispatched != 2 {
+			t.Errorf("dispatched instances = %d, want 2", dispatched)
+		}
+		if len(stub.sendBatches) != 1 || !slices.Equal(stub.sendBatches[0], []string{"i-a", "i-c"}) {
+			t.Errorf("SendCommand targets = %v, want [[i-a i-c]]", stub.sendBatches)
+		}
+	})
+
+	t.Run("reports no dispatch when every SSM agent is offline", func(t *testing.T) {
+		stub := &stubSSMClient{}
+
+		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-a", "i-b"}, "linux")
+		if err != nil {
+			t.Fatalf("sendSIGTERMToAgentsBatch() error = %v", err)
+		}
+		if dispatched != 0 {
+			t.Errorf("dispatched instances = %d, want 0", dispatched)
+		}
+		if len(stub.sendBatches) != 0 {
+			t.Errorf("SendCommand calls = %d, want 0", len(stub.sendBatches))
+		}
+	})
+
+	t.Run("attempts later batches after partial failures", func(t *testing.T) {
+		instanceIDs := make([]string, 120)
+		for i := range instanceIDs {
+			instanceIDs[i] = fmt.Sprintf("i-%03d", i)
+		}
+		firstErr := errors.New("first batch failed")
+		lastErr := errors.New("last batch failed")
+		stub := &stubSSMClient{
+			describeOut: onlineOutput(instanceIDs...),
+			sendErrors:  []error{firstErr, nil, lastErr},
+		}
+
+		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, instanceIDs, "linux")
+		if !errors.Is(err, firstErr) || !errors.Is(err, lastErr) {
+			t.Errorf("sendSIGTERMToAgentsBatch() error = %v, want both batch errors", err)
+		}
+		if dispatched != 50 {
+			t.Errorf("dispatched instances = %d, want 50", dispatched)
+		}
+		if got, want := len(stub.sendBatches), 3; got != want {
+			t.Errorf("SendCommand calls = %d, want %d", got, want)
+		}
+	})
+
+	t.Run("rejects Windows before contacting SSM", func(t *testing.T) {
+		stub := &stubSSMClient{}
+
+		dispatched, err := (&ASGDriver{}).sendSIGTERMToAgentsBatch(t.Context(), stub, []string{"i-windows"}, "windows")
+		if !errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
+			t.Errorf("sendSIGTERMToAgentsBatch() error = %v, want %v", err, ErrWindowsGracefulScaleInNotSupported)
+		}
+		if dispatched != 0 {
+			t.Errorf("dispatched instances = %d, want 0", dispatched)
+		}
+		if len(stub.describeCalls) != 0 || len(stub.sendBatches) != 0 {
+			t.Errorf("SSM calls made for Windows: describe=%d send=%d, want none", len(stub.describeCalls), len(stub.sendBatches))
+		}
+	})
 }
 
 func TestPollCommandInvocations(t *testing.T) {

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
 
@@ -420,7 +421,8 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		failedGracefulHandoff := errors.Is(gracefulScaleInErr, errNoReachableScaleInCandidates)
 		singleInstanceASG := current.DesiredCount <= 1 && current.TotalCount == 1 && len(current.InstanceIDs) == 1
 		if failedGracefulHandoff && singleInstanceASG {
-			terminated, err := s.terminateIfDangling(ctx, ec2Client, ssm.NewFromConfig(s.cfg), current.InstanceIDs[0], desired)
+			pollInterval, pollDeadline := asgDriver.ssmPollTimings()
+			terminated, err := s.terminateIfDangling(ctx, ec2Client, ssm.NewFromConfig(s.cfg), current.InstanceIDs[0], desired, pollInterval, pollDeadline)
 			if err != nil {
 				return errors.Join(gracefulScaleInErr, err)
 			}
@@ -626,15 +628,14 @@ type dangleProbeEC2API interface {
 	terminateInstancesAPI
 }
 
-type sendCommandAPI interface {
-	SendCommand(ctx context.Context, params *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error)
-}
-
 // terminateIfDangling handles the last instance in an ASG that no graceful
-// stop could reach. It asks SSM to run a service check; if SSM cannot even
-// accept the command the instance most likely never registered an agent, so we
-// terminate it directly. Returns true when the instance was terminated.
-func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeEC2API, ssmClient sendCommandAPI, instanceID string, desired int64) (bool, error) {
+// stop could reach. SSM already reported it as not Online, so we run a service
+// check and wait for the result: SendCommand only confirms the command was
+// accepted, and on a ConnectionLost instance it sits in Pending forever. Only a
+// Success result spares the instance; anything else, including a probe that
+// never runs, means we terminate it directly. Returns true when the instance
+// was terminated.
+func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeEC2API, ssmClient ssmCheckAPI, instanceID string, desired int64, pollInterval, pollDeadline time.Duration) (bool, error) {
 	log.Printf("[Elastic CI Mode] Single-instance ASG detected - checking if instance %s is a dangling instance", instanceID)
 
 	documentName := "AWS-RunShellScript"
@@ -653,7 +654,7 @@ func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeE
 		}
 	}
 
-	_, err = ssmClient.SendCommand(ctx, &ssm.SendCommandInput{
+	sendOut, err := ssmClient.SendCommand(ctx, &ssm.SendCommandInput{
 		InstanceIds:  []string{instanceID},
 		DocumentName: aws.String(documentName),
 		Parameters: map[string][]string{
@@ -661,15 +662,43 @@ func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeE
 		},
 		Comment: aws.String("Check if buildkite-agent service is running"),
 	})
-	if err == nil {
-		log.Printf("[Elastic CI Mode] Instance appears responsive, not terminating directly")
-		return false, nil
+	if err != nil {
+		log.Printf("[Elastic CI Mode] Warning: Cannot check agent status, assuming dangling instance: %v", err)
+	} else {
+		active, err := agentServiceActive(ctx, ssmClient, instanceID, aws.ToString(sendOut.Command.CommandId), pollInterval, pollDeadline)
+		if err != nil {
+			return false, err
+		}
+		if active {
+			log.Printf("[Elastic CI Mode] Instance %s reports an active buildkite-agent service, not terminating directly", instanceID)
+			return false, nil
+		}
 	}
 
-	log.Printf("[Elastic CI Mode] Warning: Cannot check agent status, assuming dangling instance: %v", err)
 	log.Printf("[Elastic CI Mode] Directly terminating probable dangling instance")
 	if err := s.directlyTerminateInstance(ctx, ec2Client, instanceID, desired); err != nil {
 		return false, fmt.Errorf("directly terminate probable dangling instance: %w", err)
+	}
+	return true, nil
+}
+
+// agentServiceActive waits for the service-check command to finish on the
+// instance and reports whether it succeeded. A probe that never reaches a
+// terminal status counts as inactive. A polling error is returned as-is: it
+// tells us nothing about the instance, so the caller must not act on it.
+func agentServiceActive(ctx context.Context, ssmClient ssmCheckAPI, instanceID, commandID string, pollInterval, pollDeadline time.Duration) (bool, error) {
+	results, err := pollCommandInvocations(ctx, ssmClient, []string{commandID}, 1, pollInterval, pollDeadline)
+	if err != nil {
+		return false, fmt.Errorf("poll agent status probe %s: %w", commandID, err)
+	}
+	invocation, ok := results[instanceID]
+	if !ok {
+		log.Printf("[Elastic CI Mode] Agent status probe on %s was not picked up within %s, assuming dangling instance", instanceID, pollDeadline)
+		return false, nil
+	}
+	if invocation.Status != ssmTypes.CommandInvocationStatusSuccess {
+		log.Printf("[Elastic CI Mode] Agent status probe on %s did not succeed (status %s), assuming dangling instance", instanceID, invocation.Status)
+		return false, nil
 	}
 	return true, nil
 }

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -631,10 +631,11 @@ type dangleProbeEC2API interface {
 // terminateIfDangling handles the last instance in an ASG that no graceful
 // stop could reach. SSM already reported it as not Online, so we run a service
 // check and wait for the result: SendCommand only confirms the command was
-// accepted, and on a ConnectionLost instance it sits in Pending forever. Only a
-// Success result spares the instance; anything else, including a probe that
-// never runs, means we terminate it directly. Returns true when the instance
-// was terminated.
+// accepted, and on a ConnectionLost instance it sits in Pending forever. A
+// Success result spares the instance. Anything else only proves the SSM agent
+// did not run the probe, not that buildkite-agent is down, so we terminate
+// only when Buildkite also reports no agents connected on the queue. Returns
+// true when the instance was terminated.
 func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeEC2API, ssmClient ssmCheckAPI, instanceID string, desired int64, pollInterval, pollDeadline time.Duration) (bool, error) {
 	log.Printf("[Elastic CI Mode] Single-instance ASG detected - checking if instance %s is a dangling instance", instanceID)
 
@@ -663,7 +664,7 @@ func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeE
 		Comment: aws.String("Check if buildkite-agent service is running"),
 	})
 	if err != nil {
-		log.Printf("[Elastic CI Mode] Warning: Cannot check agent status, assuming dangling instance: %v", err)
+		log.Printf("[Elastic CI Mode] Warning: Cannot check agent status on %s: %v", instanceID, err)
 	} else {
 		active, err := agentServiceActive(ctx, ssmClient, instanceID, aws.ToString(sendOut.Command.CommandId), pollInterval, pollDeadline)
 		if err != nil {
@@ -675,6 +676,18 @@ func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeE
 		}
 	}
 
+	// The queue metrics that drove this scale-in are from before the probe
+	// wait, and the agent may have taken a job since. Ask Buildkite again and
+	// only hard-kill when nothing is connected on the queue.
+	metrics, err := s.bk.GetAgentMetrics(ctx)
+	if err != nil {
+		return false, fmt.Errorf("confirm no agents connected before terminating %s: %w", instanceID, err)
+	}
+	if metrics.TotalAgents > 0 {
+		log.Printf("[Elastic CI Mode] Buildkite still reports %d agent(s) connected on the queue, not terminating %s directly", metrics.TotalAgents, instanceID)
+		return false, nil
+	}
+
 	log.Printf("[Elastic CI Mode] Directly terminating probable dangling instance")
 	if err := s.directlyTerminateInstance(ctx, ec2Client, instanceID, desired); err != nil {
 		return false, fmt.Errorf("directly terminate probable dangling instance: %w", err)
@@ -683,9 +696,10 @@ func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeE
 }
 
 // agentServiceActive waits for the service-check command to finish on the
-// instance and reports whether it succeeded. A probe that never reaches a
-// terminal status counts as inactive. A polling error is returned as-is: it
-// tells us nothing about the instance, so the caller must not act on it.
+// instance and reports whether it succeeded. Only Success is a positive answer;
+// a probe that never reaches a terminal status is inconclusive and reported as
+// not active. A polling error is returned as-is: it tells us nothing about the
+// instance, so the caller must not act on it.
 func agentServiceActive(ctx context.Context, ssmClient ssmCheckAPI, instanceID, commandID string, pollInterval, pollDeadline time.Duration) (bool, error) {
 	results, err := pollCommandInvocations(ctx, ssmClient, []string{commandID}, 1, pollInterval, pollDeadline)
 	if err != nil {
@@ -693,11 +707,11 @@ func agentServiceActive(ctx context.Context, ssmClient ssmCheckAPI, instanceID, 
 	}
 	invocation, ok := results[instanceID]
 	if !ok {
-		log.Printf("[Elastic CI Mode] Agent status probe on %s was not picked up within %s, assuming dangling instance", instanceID, pollDeadline)
+		log.Printf("[Elastic CI Mode] Agent status probe on %s was not picked up within %s", instanceID, pollDeadline)
 		return false, nil
 	}
 	if invocation.Status != ssmTypes.CommandInvocationStatusSuccess {
-		log.Printf("[Elastic CI Mode] Agent status probe on %s did not succeed (status %s), assuming dangling instance", instanceID, invocation.Status)
+		log.Printf("[Elastic CI Mode] Agent status probe on %s did not succeed (status %s)", instanceID, invocation.Status)
 		return false, nil
 	}
 	return true, nil

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -48,7 +48,7 @@ type Scaler struct {
 	autoscaling interface {
 		Describe(ctx context.Context) (AutoscaleGroupDetails, error)
 		SetDesiredCapacity(ctx context.Context, count int64) error
-		SendSIGTERMToAgents(ctx context.Context, instanceID string) error
+		SendSIGTERMToAgentsBatch(ctx context.Context, instanceIDs []string) (int, error)
 		CleanupDanglingInstances(ctx context.Context, minimumInstanceUptime time.Duration, maxDanglingInstancesToCheck int) error
 	}
 	bk interface {
@@ -393,7 +393,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 	instancesToTerminate := current.DesiredCount - desired
 
 	// In Elastic CI Mode, use graceful termination if we have instance IDs
-	if _, ok := s.autoscaling.(*ASGDriver); ok && s.elasticCIMode && len(current.InstanceIDs) > 0 && instancesToTerminate > 0 {
+	if asgDriver, ok := s.autoscaling.(*ASGDriver); ok && s.elasticCIMode && len(current.InstanceIDs) > 0 && instancesToTerminate > 0 {
 		log.Printf("[Elastic CI Mode] Using graceful termination for %d instances", instancesToTerminate)
 
 		// Determine instances to terminate by sorting by launch time (oldest first)
@@ -411,9 +411,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 			ec2Svc := ec2.NewFromConfig(s.cfg)
 
 			instances := make([]instanceInfo, 0, len(current.InstanceIDs))
-			describeResult, err := ec2Svc.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-				InstanceIds: current.InstanceIDs,
-			})
+			describeResult, err := describeInstancesTolerant(ctx, ec2Svc, current.InstanceIDs, asgDriver.Name)
 
 			if err != nil {
 				log.Printf("[Elastic CI Mode] Warning: Could not get instance launch times: %v", err)
@@ -460,41 +458,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		}
 
 		log.Printf("[Elastic CI Mode] Attempting graceful termination for %d instance(s): %v", len(instancesForTermination), instancesForTermination)
-
-		sigTermErrors := 0
-		sigTermSkipped := 0
-		sigTermSuccess := 0
-		for _, instanceID := range instancesForTermination {
-			if err := s.autoscaling.SendSIGTERMToAgents(ctx, instanceID); err != nil {
-				if errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
-					sigTermSkipped++
-				} else {
-					log.Printf("⚠️  Failed to send SIGTERM to instance %s: %v", instanceID, err)
-					sigTermErrors++
-				}
-			} else {
-				log.Printf("✅ Successfully sent SIGTERM to instance %s", instanceID)
-				sigTermSuccess++
-			}
-		}
-
-		if sigTermErrors > 0 {
-			log.Printf("⚠️  Failed to send SIGTERM to %d/%d instances",
-				sigTermErrors, len(instancesForTermination))
-		}
-		if sigTermSkipped > 0 {
-			log.Printf("ℹ️  Skipped %d Windows instance(s) - graceful scale-in not supported, will be terminated directly by ASG",
-				sigTermSkipped)
-		}
-		if sigTermSuccess > 0 {
-			log.Printf("✅ Successfully sent SIGTERM to %d instance(s)", sigTermSuccess)
-		}
-
-		log.Printf("[Elastic CI Mode] Updating ASG desired capacity to %d", desired)
-		if err := s.setDesiredCapacity(ctx, desired); err != nil {
-			log.Printf("CRITICAL: [Elastic CI Mode] Failed to set desired capacity to %d after sending SIGTERMs: %v. ASG might replace terminated instances.", desired, err)
-
-		}
+		s.gracefullyScaleIn(ctx, instancesForTermination, desired)
 
 		if current.DesiredCount <= 1 && len(current.InstanceIDs) == 1 {
 			instanceID := current.InstanceIDs[0]
@@ -544,7 +508,6 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 				log.Printf("[Elastic CI Mode] Instance appears responsive, not terminating directly")
 			}
 		}
-		s.scaleInParams.LastEvent = time.Now()
 		return nil
 	} else {
 		log.Printf("Using standard scale-in (Elastic CI Mode disabled or no instances to terminate)")
@@ -553,6 +516,29 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		}
 		s.scaleInParams.LastEvent = time.Now()
 		return nil
+	}
+}
+
+func (s *Scaler) gracefullyScaleIn(ctx context.Context, instanceIDs []string, desired int64) {
+	// Elastic CI Stack agents self-terminate and decrement desired capacity
+	// after draining. Setting desired capacity here for Linux would decrement
+	// twice when those targeted terminations complete.
+	dispatched, err := s.autoscaling.SendSIGTERMToAgentsBatch(ctx, instanceIDs)
+	if err != nil {
+		if errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
+			log.Printf("ℹ️  Skipped %d Windows instance(s) - graceful scale-in not supported, will be terminated directly by ASG", len(instanceIDs))
+			if err := s.setDesiredCapacity(ctx, desired); err != nil {
+				log.Printf("CRITICAL: [Elastic CI Mode] Failed to set desired capacity to %d for Windows instances: %v", desired, err)
+			} else {
+				s.scaleInParams.LastEvent = time.Now()
+			}
+			return
+		}
+
+		log.Printf("⚠️  Failed to send graceful-stop command to one or more instances: %v", err)
+	}
+	if dispatched > 0 {
+		s.scaleInParams.LastEvent = time.Now()
 	}
 }
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -461,7 +461,13 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		log.Printf("[Elastic CI Mode] Attempting graceful termination for %d instance(s): %v", len(instancesForTermination), instancesForTermination)
 		gracefulScaleInErr := s.gracefullyScaleIn(ctx, instancesForTermination, desired)
 
-		if current.DesiredCount <= 1 && len(current.InstanceIDs) == 1 {
+		// Only probe when nothing was reachable over SSM. A failed SSM or EC2
+		// API call tells us nothing about the instance, and the probe would
+		// most likely fail the same way before hard-killing an agent that
+		// might be mid-job.
+		failedGracefulHandoff := errors.Is(gracefulScaleInErr, errNoReachableScaleInCandidates)
+		singleInstanceASG := current.DesiredCount <= 1 && current.TotalCount == 1 && len(current.InstanceIDs) == 1
+		if failedGracefulHandoff && singleInstanceASG {
 			instanceID := current.InstanceIDs[0]
 			log.Printf("[Elastic CI Mode] Single-instance ASG detected - checking if instance %s is a dangling instance", instanceID)
 
@@ -502,8 +508,8 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 				log.Printf("[Elastic CI Mode] Warning: Cannot check agent status, assuming dangling instance: %v", err)
 				log.Printf("[Elastic CI Mode] Directly terminating probable dangling instance")
 
-				if termErr := directlyTerminateInstance(ctx, ec2Client, instanceID); termErr != nil {
-					log.Printf("[Elastic CI Mode] Error: Failed to terminate: %v", termErr)
+				if termErr := s.directlyTerminateInstance(ctx, ec2Client, instanceID, desired); termErr != nil {
+					return errors.Join(gracefulScaleInErr, fmt.Errorf("directly terminate probable dangling instance: %w", termErr))
 				}
 			} else {
 				log.Printf("[Elastic CI Mode] Instance appears responsive, not terminating directly")
@@ -629,9 +635,17 @@ func (s *Scaler) setDesiredCapacity(ctx context.Context, desired int64) error {
 	return nil
 }
 
-// directlyTerminateInstance terminates an EC2 instance directly via EC2 API
-// This is a helper function for dangling instance termination
-func directlyTerminateInstance(ctx context.Context, ec2Client *ec2.Client, instanceID string) error {
+type terminateInstancesAPI interface {
+	TerminateInstances(ctx context.Context, params *ec2.TerminateInstancesInput, optFns ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error)
+}
+
+// directlyTerminateInstance lowers desired capacity before terminating an EC2
+// instance so the ASG does not launch a replacement.
+func (s *Scaler) directlyTerminateInstance(ctx context.Context, ec2Client terminateInstancesAPI, instanceID string, desired int64) error {
+	if err := s.setDesiredCapacity(ctx, desired); err != nil {
+		return fmt.Errorf("set desired capacity before terminating instance: %w", err)
+	}
+
 	_, err := ec2Client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{instanceID},
 	})

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -327,13 +327,9 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 
 	// Special Elastic CI Stack mode with additional safety checks
 	if s.elasticCIMode && s.scaleInParams.CooldownPeriod > 0 {
-		// Only walk the ASG activity history when this process has no
-		// scale-in on record, e.g. cold-start seeding failed. Once we've sent
-		// a graceful stop ourselves, LastEvent is the better signal: Elastic
-		// CI Stack agents decrement desired capacity with the same activity
-		// cause whether we asked them to stop or they idled out on their own,
-		// so the history can't tell our scale-ins apart from idle churn.
-		if driver, ok := s.autoscaling.(*ASGDriver); ok && s.scaleInParams.LastEvent.IsZero() {
+		// Check the ASG activity history even when LastEvent is set. Other
+		// Lambda containers scale in too, and only the history sees them.
+		if driver, ok := s.autoscaling.(*ASGDriver); ok {
 			ctx, cancel := context.WithTimeout(ctx, driver.scalingActivitiesTimeout)
 			defer cancel()
 
@@ -347,7 +343,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 				lastScaleInTime := *lastScaleInActivity.StartTime
 				timeSinceLastScaleIn := time.Since(lastScaleInTime)
 
-				// Remember it so the next poll uses the in-process cooldown
+				// Remember it so polls still inside the cooldown return early
 				// instead of paging through the history again.
 				s.scaleInParams.LastEvent = lastScaleInTime
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -317,9 +317,13 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 
 	// Special Elastic CI Stack mode with additional safety checks
 	if s.elasticCIMode {
-		// Check for recent ASG scale-down activity to avoid scaling down too quickly
-		// Only do this check if we have access to the ASG activities
-		if driver, ok := s.autoscaling.(*ASGDriver); ok {
+		// Only walk the ASG activity history when this process has no
+		// scale-in on record, e.g. cold-start seeding failed. Once we've sent
+		// a graceful stop ourselves, LastEvent is the better signal: Elastic
+		// CI Stack agents decrement desired capacity with the same activity
+		// cause whether we asked them to stop or they idled out on their own,
+		// so the history can't tell our scale-ins apart from idle churn.
+		if driver, ok := s.autoscaling.(*ASGDriver); ok && s.scaleInParams.LastEvent.IsZero() {
 			// In ElasticCIMode, override the page limit to allow unlimited pages
 			if driver.MaxDescribeScalingActivitiesPages >= 0 {
 				// Override to allow unlimited pages (-1) for full activity history in ElasticCIMode
@@ -339,6 +343,10 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 				// Check how recently the ASG scaled down
 				lastScaleInTime := *lastScaleInActivity.StartTime
 				timeSinceLastScaleIn := time.Since(lastScaleInTime)
+
+				// Remember it so the next poll uses the in-process cooldown
+				// instead of paging through the history again.
+				s.scaleInParams.LastEvent = lastScaleInTime
 
 				// Check if we're in cooldown period based on the last ASG scale-in activity
 				if s.scaleInParams.CooldownPeriod > 0 && timeSinceLastScaleIn < s.scaleInParams.CooldownPeriod {

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -25,25 +25,27 @@ type ScaleParams struct {
 }
 
 type Params struct {
-	AutoScalingGroupName           string
-	AgentsPerInstance              int
-	BuildkiteAgentToken            string
-	BuildkiteQueue                 string
-	UserAgent                      string
-	PublishCloudWatchMetrics       bool
-	DryRun                         bool
-	IncludeWaiting                 bool
-	ScaleInParams                  ScaleParams
-	ScaleOutParams                 ScaleParams
-	InstanceBuffer                 int
-	ScaleOnlyAfterAllEvent         bool
-	AvailabilityThreshold          float64       // Threshold for agent availability (default 50%, all modes)
-	ASGActivityCooldown            time.Duration // How long to wait after an ASG activity before scaling again
-	ElasticCIMode                  bool          // Special mode for Elastic CI Stack with additional safety checks
-	MinimumInstanceUptime          time.Duration // How long instance should be online before being eligible for dangling instance check
-	MaxDanglingInstancesToCheck    int           // Maximum number of instances to check for dangling instances (only used for dangling instance scanning, not for normal scale-in)
-	MaxInstanceCap                 int           // Maximum instance count cap (0 means no cap)
-	DanglingInstancesCheckInterval time.Duration // Interval between dangling-instance checks; used to rotate the check window. Defaults to 60s when 0.
+	AutoScalingGroupName              string
+	AgentsPerInstance                 int
+	BuildkiteAgentToken               string
+	BuildkiteQueue                    string
+	UserAgent                         string
+	PublishCloudWatchMetrics          bool
+	DryRun                            bool
+	IncludeWaiting                    bool
+	ScaleInParams                     ScaleParams
+	ScaleOutParams                    ScaleParams
+	InstanceBuffer                    int
+	ScaleOnlyAfterAllEvent            bool
+	AvailabilityThreshold             float64       // Threshold for agent availability (default 50%, all modes)
+	ASGActivityCooldown               time.Duration // How long to wait after an ASG activity before scaling again
+	ASGActivityTimeout                time.Duration // Maximum time to wait when retrieving ASG scaling activities
+	MaxDescribeScalingActivitiesPages int           // Maximum DescribeScalingActivities pages; non-positive means unlimited
+	ElasticCIMode                     bool          // Special mode for Elastic CI Stack with additional safety checks
+	MinimumInstanceUptime             time.Duration // How long instance should be online before being eligible for dangling instance check
+	MaxDanglingInstancesToCheck       int           // Maximum number of instances to check for dangling instances (only used for dangling instance scanning, not for normal scale-in)
+	MaxInstanceCap                    int           // Maximum instance count cap (0 means no cap)
+	DanglingInstancesCheckInterval    time.Duration // Interval between dangling-instance checks; used to rotate the check window. Defaults to 60s when 0.
 }
 
 type Scaler struct {
@@ -105,18 +107,25 @@ func NewScaler(client *buildkite.Client, cfg aws.Config, params Params) (*Scaler
 		return scaler, nil
 	}
 
+	asgActivityTimeout := params.ASGActivityTimeout
+	if asgActivityTimeout <= 0 {
+		asgActivityTimeout = 10 * time.Second
+	}
+
 	danglingInstancesCheckInterval := params.DanglingInstancesCheckInterval
 	if danglingInstancesCheckInterval <= 0 {
 		danglingInstancesCheckInterval = time.Minute
 	}
 
 	scaler.autoscaling = &ASGDriver{
-		Name:                           params.AutoScalingGroupName,
-		Cfg:                            cfg,
-		ElasticCIMode:                  params.ElasticCIMode,
-		MinimumInstanceUptime:          params.MinimumInstanceUptime,
-		MaxDanglingInstancesToCheck:    params.MaxDanglingInstancesToCheck,
-		DanglingInstancesCheckInterval: danglingInstancesCheckInterval,
+		Name:                              params.AutoScalingGroupName,
+		Cfg:                               cfg,
+		MaxDescribeScalingActivitiesPages: params.MaxDescribeScalingActivitiesPages,
+		ElasticCIMode:                     params.ElasticCIMode,
+		MinimumInstanceUptime:             params.MinimumInstanceUptime,
+		MaxDanglingInstancesToCheck:       params.MaxDanglingInstancesToCheck,
+		DanglingInstancesCheckInterval:    danglingInstancesCheckInterval,
+		scalingActivitiesTimeout:          asgActivityTimeout,
 	}
 
 	if params.PublishCloudWatchMetrics {
@@ -317,7 +326,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 	}
 
 	// Special Elastic CI Stack mode with additional safety checks
-	if s.elasticCIMode {
+	if s.elasticCIMode && s.scaleInParams.CooldownPeriod > 0 {
 		// Only walk the ASG activity history when this process has no
 		// scale-in on record, e.g. cold-start seeding failed. Once we've sent
 		// a graceful stop ourselves, LastEvent is the better signal: Elastic
@@ -325,21 +334,14 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		// cause whether we asked them to stop or they idled out on their own,
 		// so the history can't tell our scale-ins apart from idle churn.
 		if driver, ok := s.autoscaling.(*ASGDriver); ok && s.scaleInParams.LastEvent.IsZero() {
-			// In ElasticCIMode, override the page limit to allow unlimited pages
-			if driver.MaxDescribeScalingActivitiesPages >= 0 {
-				// Override to allow unlimited pages (-1) for full activity history in ElasticCIMode
-				log.Printf("ℹ️ [Elastic CI Mode] Setting MAX_DESCRIBE_SCALING_ACTIVITIES_PAGES from %d to -1 (unlimited) for better safety checks",
-					driver.MaxDescribeScalingActivitiesPages)
-				driver.MaxDescribeScalingActivitiesPages = -1
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			ctx, cancel := context.WithTimeout(ctx, driver.scalingActivitiesTimeout)
 			defer cancel()
 
-			// Get the last scale-in activity from ASG history
-			_, lastScaleInActivity, err := driver.GetLastScalingInAndOutActivity(ctx, false, true)
+			// Get the last scale-in activity within the configured cooldown period.
+			activitySince := time.Now().Add(-s.scaleInParams.CooldownPeriod)
+			_, lastScaleInActivity, err := driver.GetLastScalingInAndOutActivity(ctx, false, true, activitySince)
 			if err != nil {
-				log.Printf("⚠️ [Elastic CI Mode] Could not check last ASG scale-in activity: %v", err)
+				return fmt.Errorf("check last ASG scale-in activity: %w", err)
 			} else if lastScaleInActivity != nil && lastScaleInActivity.StartTime != nil {
 				// Check how recently the ASG scaled down
 				lastScaleInTime := *lastScaleInActivity.StartTime

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -420,50 +420,12 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		failedGracefulHandoff := errors.Is(gracefulScaleInErr, errNoReachableScaleInCandidates)
 		singleInstanceASG := current.DesiredCount <= 1 && current.TotalCount == 1 && len(current.InstanceIDs) == 1
 		if failedGracefulHandoff && singleInstanceASG {
-			instanceID := current.InstanceIDs[0]
-			log.Printf("[Elastic CI Mode] Single-instance ASG detected - checking if instance %s is a dangling instance", instanceID)
-
-			// Only consider direct termination for dangling instances
-			ssmClient := ssm.NewFromConfig(s.cfg)
-
-			// Detect platform for this instance
-			descResp, descErr := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-				InstanceIds: []string{instanceID},
-			})
-
-			documentName := "AWS-RunShellScript"
-			checkCommand := "systemctl is-active buildkite-agent"
-			if descErr != nil {
-				log.Printf("[Elastic CI Mode] Warning: Failed to detect platform for %s, defaulting to Linux: %v", instanceID, descErr)
-			} else if len(descResp.Reservations) > 0 && len(descResp.Reservations[0].Instances) > 0 {
-				instance := descResp.Reservations[0].Instances[0]
-				if strings.EqualFold(string(instance.Platform), "windows") {
-					documentName = "AWS-RunPowerShellScript"
-					checkCommand = "nssm status buildkite-agent"
-					log.Printf("[Elastic CI Mode] Detected Windows platform for instance %s", instanceID)
-				}
-			}
-
-			// Try to check if buildkite-agent is running via SSM
-			_, err := ssmClient.SendCommand(ctx, &ssm.SendCommandInput{
-				InstanceIds:  []string{instanceID},
-				DocumentName: aws.String(documentName),
-				Parameters: map[string][]string{
-					"commands": {checkCommand},
-				},
-				Comment: aws.String("Check if buildkite-agent service is running"),
-			})
-
-			// Only terminate if we can't check agent status, suggesting it's likely a dangling instance
+			terminated, err := s.terminateIfDangling(ctx, ec2Client, ssm.NewFromConfig(s.cfg), current.InstanceIDs[0], desired)
 			if err != nil {
-				log.Printf("[Elastic CI Mode] Warning: Cannot check agent status, assuming dangling instance: %v", err)
-				log.Printf("[Elastic CI Mode] Directly terminating probable dangling instance")
-
-				if termErr := s.directlyTerminateInstance(ctx, ec2Client, instanceID, desired); termErr != nil {
-					return errors.Join(gracefulScaleInErr, fmt.Errorf("directly terminate probable dangling instance: %w", termErr))
-				}
-			} else {
-				log.Printf("[Elastic CI Mode] Instance appears responsive, not terminating directly")
+				return errors.Join(gracefulScaleInErr, err)
+			}
+			if terminated {
+				return nil
 			}
 		}
 		return gracefulScaleInErr
@@ -657,6 +619,59 @@ func oldestInstances(ctx context.Context, client describeInstancesAPI, instanceI
 			len(selected), instances[0].LaunchTime.Format(time.RFC3339))
 	}
 	return selected, nil
+}
+
+type dangleProbeEC2API interface {
+	describeInstancesAPI
+	terminateInstancesAPI
+}
+
+type sendCommandAPI interface {
+	SendCommand(ctx context.Context, params *ssm.SendCommandInput, optFns ...func(*ssm.Options)) (*ssm.SendCommandOutput, error)
+}
+
+// terminateIfDangling handles the last instance in an ASG that no graceful
+// stop could reach. It asks SSM to run a service check; if SSM cannot even
+// accept the command the instance most likely never registered an agent, so we
+// terminate it directly. Returns true when the instance was terminated.
+func (s *Scaler) terminateIfDangling(ctx context.Context, ec2Client dangleProbeEC2API, ssmClient sendCommandAPI, instanceID string, desired int64) (bool, error) {
+	log.Printf("[Elastic CI Mode] Single-instance ASG detected - checking if instance %s is a dangling instance", instanceID)
+
+	documentName := "AWS-RunShellScript"
+	checkCommand := "systemctl is-active buildkite-agent"
+	descResp, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	})
+	if err != nil {
+		log.Printf("[Elastic CI Mode] Warning: Failed to detect platform for %s, defaulting to Linux: %v", instanceID, err)
+	} else if len(descResp.Reservations) > 0 && len(descResp.Reservations[0].Instances) > 0 {
+		instance := descResp.Reservations[0].Instances[0]
+		if strings.EqualFold(string(instance.Platform), "windows") {
+			documentName = "AWS-RunPowerShellScript"
+			checkCommand = "nssm status buildkite-agent"
+			log.Printf("[Elastic CI Mode] Detected Windows platform for instance %s", instanceID)
+		}
+	}
+
+	_, err = ssmClient.SendCommand(ctx, &ssm.SendCommandInput{
+		InstanceIds:  []string{instanceID},
+		DocumentName: aws.String(documentName),
+		Parameters: map[string][]string{
+			"commands": {checkCommand},
+		},
+		Comment: aws.String("Check if buildkite-agent service is running"),
+	})
+	if err == nil {
+		log.Printf("[Elastic CI Mode] Instance appears responsive, not terminating directly")
+		return false, nil
+	}
+
+	log.Printf("[Elastic CI Mode] Warning: Cannot check agent status, assuming dangling instance: %v", err)
+	log.Printf("[Elastic CI Mode] Directly terminating probable dangling instance")
+	if err := s.directlyTerminateInstance(ctx, ec2Client, instanceID, desired); err != nil {
+		return false, fmt.Errorf("directly terminate probable dangling instance: %w", err)
+	}
+	return true, nil
 }
 
 type buildkiteDriver struct {

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -3,6 +3,7 @@ package scaler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
 	"math"
 	"sort"
@@ -458,7 +459,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 		}
 
 		log.Printf("[Elastic CI Mode] Attempting graceful termination for %d instance(s): %v", len(instancesForTermination), instancesForTermination)
-		s.gracefullyScaleIn(ctx, instancesForTermination, desired)
+		gracefulScaleInErr := s.gracefullyScaleIn(ctx, instancesForTermination, desired)
 
 		if current.DesiredCount <= 1 && len(current.InstanceIDs) == 1 {
 			instanceID := current.InstanceIDs[0]
@@ -508,7 +509,7 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 				log.Printf("[Elastic CI Mode] Instance appears responsive, not terminating directly")
 			}
 		}
-		return nil
+		return gracefulScaleInErr
 	} else {
 		log.Printf("Using standard scale-in (Elastic CI Mode disabled or no instances to terminate)")
 		if err := s.setDesiredCapacity(ctx, desired); err != nil {
@@ -519,27 +520,41 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 	}
 }
 
-func (s *Scaler) gracefullyScaleIn(ctx context.Context, instanceIDs []string, desired int64) {
+// errNoReachableScaleInCandidates means no graceful-stop command went out
+// because none of the candidates is online in SSM. Kept separate from API
+// errors so callers can tell "nothing to talk to" from "the call failed".
+var errNoReachableScaleInCandidates = errors.New("no graceful-stop commands dispatched: no scale-in candidates reachable via SSM")
+
+// gracefullyScaleIn asks the selected instances to drain and stop. Windows
+// instances can't be drained this way, so they get a desired-capacity update
+// and the ASG terminates them.
+func (s *Scaler) gracefullyScaleIn(ctx context.Context, instanceIDs []string, desired int64) error {
 	// Elastic CI Stack agents self-terminate and decrement desired capacity
 	// after draining. Setting desired capacity here for Linux would decrement
 	// twice when those targeted terminations complete.
 	dispatched, err := s.autoscaling.SendSIGTERMToAgentsBatch(ctx, instanceIDs)
-	if err != nil {
-		if errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
-			log.Printf("ℹ️  Skipped %d Windows instance(s) - graceful scale-in not supported, will be terminated directly by ASG", len(instanceIDs))
-			if err := s.setDesiredCapacity(ctx, desired); err != nil {
-				log.Printf("CRITICAL: [Elastic CI Mode] Failed to set desired capacity to %d for Windows instances: %v", desired, err)
-			} else {
-				s.scaleInParams.LastEvent = time.Now()
-			}
-			return
+	if errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
+		log.Printf("ℹ️  Skipped %d Windows instance(s) - graceful scale-in not supported, will be terminated directly by ASG", len(instanceIDs))
+		if err := s.setDesiredCapacity(ctx, desired); err != nil {
+			return fmt.Errorf("set desired capacity to %d for windows instances: %w", desired, err)
 		}
-
+		s.scaleInParams.LastEvent = time.Now()
+		return nil
+	}
+	if err != nil {
 		log.Printf("⚠️  Failed to send graceful-stop command to one or more instances: %v", err)
+	}
+	if dispatched == 0 && len(instanceIDs) > 0 {
+		s.scaleInParams.LastEvent = time.Now()
+		if err != nil {
+			return err
+		}
+		return errNoReachableScaleInCandidates
 	}
 	if dispatched > 0 {
 		s.scaleInParams.LastEvent = time.Now()
 	}
+	return nil
 }
 
 func (s *Scaler) scaleOut(ctx context.Context, desired int64, current AutoscaleGroupDetails) error {

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -546,7 +546,7 @@ func (s *Scaler) gracefullyScaleIn(ctx context.Context, instanceIDs []string, de
 	// Elastic CI Stack agents self-terminate and decrement desired capacity
 	// after draining. Setting desired capacity here for Linux would decrement
 	// twice when those targeted terminations complete.
-	dispatched, err := s.autoscaling.SendSIGTERMToAgentsBatch(ctx, instanceIDs)
+	accepted, err := s.autoscaling.SendSIGTERMToAgentsBatch(ctx, instanceIDs)
 	if errors.Is(err, ErrWindowsGracefulScaleInNotSupported) {
 		log.Printf("ℹ️  Skipped %d Windows instance(s) - graceful scale-in not supported, will be terminated directly by ASG", len(instanceIDs))
 		if err := s.setDesiredCapacity(ctx, desired); err != nil {
@@ -558,17 +558,23 @@ func (s *Scaler) gracefullyScaleIn(ctx context.Context, instanceIDs []string, de
 	if err != nil {
 		log.Printf("⚠️  Failed to send graceful-stop command to one or more instances: %v", err)
 	}
-	if dispatched == 0 && len(instanceIDs) > 0 {
-		s.scaleInParams.LastEvent = time.Now()
-		if err != nil {
-			return err
-		}
-		return errNoReachableScaleInCandidates
+	if len(instanceIDs) == 0 {
+		return nil
 	}
-	if dispatched > 0 {
-		s.scaleInParams.LastEvent = time.Now()
+
+	// Every attempt starts the cooldown. Instances that accepted the command
+	// stay in the ASG until they've drained, so retrying sooner would just
+	// pick the same ones again, and a failed attempt should back off rather
+	// than retry on every poll.
+	s.scaleInParams.LastEvent = time.Now()
+
+	if accepted > 0 {
+		return nil
 	}
-	return nil
+	if err != nil {
+		return err
+	}
+	return errNoReachableScaleInCandidates
 }
 
 func (s *Scaler) scaleOut(ctx context.Context, desired int64, current AutoscaleGroupDetails) error {

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -1,12 +1,13 @@
 package scaler
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"log"
 	"math"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -405,65 +406,10 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 	if asgDriver, ok := s.autoscaling.(*ASGDriver); ok && s.elasticCIMode && len(current.InstanceIDs) > 0 && instancesToTerminate > 0 {
 		log.Printf("[Elastic CI Mode] Using graceful termination for %d instances", instancesToTerminate)
 
-		// Determine instances to terminate by sorting by launch time (oldest first)
-		maxToTerminate := instancesToTerminate
-
-		instancesForTermination := make([]string, 0, maxToTerminate)
-
-		if len(current.InstanceIDs) > 0 {
-			// Define a struct to hold instance info for sorting
-			type instanceInfo struct {
-				ID         string
-				LaunchTime time.Time
-			}
-
-			ec2Svc := ec2.NewFromConfig(s.cfg)
-
-			instances := make([]instanceInfo, 0, len(current.InstanceIDs))
-			describeResult, err := describeInstancesTolerant(ctx, ec2Svc, current.InstanceIDs, asgDriver.Name)
-
-			if err != nil {
-				log.Printf("[Elastic CI Mode] Warning: Could not get instance launch times: %v", err)
-				// Fall back to unsorted if we can't get launch times
-				instancesForTermination = current.InstanceIDs
-				if int64(len(instancesForTermination)) > maxToTerminate {
-					instancesForTermination = instancesForTermination[:maxToTerminate]
-				}
-			} else {
-				// Process results and build list of instances with launch times
-				// We need to iterate through reservations as that's how AWS groups the instances
-				for _, reservation := range describeResult.Reservations {
-					for _, instance := range reservation.Instances {
-						if instance.InstanceId != nil && instance.LaunchTime != nil {
-							instances = append(instances, instanceInfo{
-								ID:         *instance.InstanceId,
-								LaunchTime: *instance.LaunchTime,
-							})
-						}
-					}
-				}
-
-				// Sort instances by launch time (oldest first)
-				sort.Slice(instances, func(i, j int) bool {
-					return instances[i].LaunchTime.Before(instances[j].LaunchTime)
-				})
-
-				limit := int(maxToTerminate)
-				if len(instances) < limit {
-					limit = len(instances)
-				}
-
-				instancesForTermination = make([]string, limit)
-				for i := 0; i < limit; i++ {
-					instancesForTermination[i] = instances[i].ID
-				}
-
-				if len(instances) > 0 {
-					oldestTime := instances[0].LaunchTime.Format(time.RFC3339)
-					log.Printf("[Elastic CI Mode] Selecting %d oldest instances by launch time for termination (oldest from %s)",
-						len(instancesForTermination), oldestTime)
-				}
-			}
+		ec2Client := ec2.NewFromConfig(s.cfg)
+		instancesForTermination, err := oldestInstances(ctx, ec2Client, current.InstanceIDs, instancesToTerminate, asgDriver.Name)
+		if err != nil {
+			return fmt.Errorf("select scale-in candidates: %w", err)
 		}
 
 		log.Printf("[Elastic CI Mode] Attempting graceful termination for %d instance(s): %v", len(instancesForTermination), instancesForTermination)
@@ -481,7 +427,6 @@ func (s *Scaler) scaleIn(ctx context.Context, desired int64, current AutoscaleGr
 
 			// Only consider direct termination for dangling instances
 			ssmClient := ssm.NewFromConfig(s.cfg)
-			ec2Client := ec2.NewFromConfig(s.cfg)
 
 			// Detect platform for this instance
 			descResp, descErr := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
@@ -669,6 +614,51 @@ func (s *Scaler) directlyTerminateInstance(ctx context.Context, ec2Client termin
 
 	log.Printf("[Elastic CI Mode] Successfully terminated instance %s via EC2 API", instanceID)
 	return nil
+}
+
+// oldestInstances picks up to n instances to stop, oldest launch first.
+//
+// Draining instances stay in the ASG until their job finishes, so a later poll
+// sees the same set and must pick the same instances. Anything else stops more
+// agents than the scaling target asked for. Instance ID breaks launch-time ties
+// because instances launched in one batch often share a timestamp. When the
+// describe call fails we return the error instead of guessing from ASG order,
+// which AWS does not keep stable.
+func oldestInstances(ctx context.Context, client describeInstancesAPI, instanceIDs []string, n int64, asgName string) ([]string, error) {
+	describeResult, err := describeInstancesTolerant(ctx, client, instanceIDs, asgName)
+	if err != nil {
+		return nil, fmt.Errorf("describe instance launch times: %w", err)
+	}
+
+	type instanceInfo struct {
+		ID         string
+		LaunchTime time.Time
+	}
+	instances := make([]instanceInfo, 0, len(instanceIDs))
+	for _, reservation := range describeResult.Reservations {
+		for _, instance := range reservation.Instances {
+			if instance.InstanceId == nil || instance.LaunchTime == nil {
+				continue
+			}
+			instances = append(instances, instanceInfo{ID: *instance.InstanceId, LaunchTime: *instance.LaunchTime})
+		}
+	}
+
+	slices.SortFunc(instances, func(a, b instanceInfo) int {
+		return cmp.Or(a.LaunchTime.Compare(b.LaunchTime), cmp.Compare(a.ID, b.ID))
+	})
+
+	limit := min(int(n), len(instances))
+	selected := make([]string, 0, limit)
+	for _, instance := range instances[:limit] {
+		selected = append(selected, instance.ID)
+	}
+
+	if len(selected) > 0 {
+		log.Printf("[Elastic CI Mode] Selecting %d oldest instances by launch time for termination (oldest from %s)",
+			len(selected), instances[0].LaunchTime.Format(time.RFC3339))
+	}
+	return selected, nil
 }
 
 type buildkiteDriver struct {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmTypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
 
@@ -608,9 +610,18 @@ func TestOldestInstancesFailsClosedOnDescribeError(t *testing.T) {
 }
 
 func TestTerminateIfDangling(t *testing.T) {
+	probeResult := func(status ssmTypes.CommandInvocationStatus) []stubListResponse {
+		return []stubListResponse{{out: &ssm.ListCommandInvocationsOutput{
+			CommandInvocations: []ssmTypes.CommandInvocation{{InstanceId: aws.String("i-a"), Status: status}},
+		}}}
+	}
+	listErr := errors.New("ListCommandInvocations throttled")
+
 	for _, tc := range []struct {
 		name           string
 		sendErr        error
+		listResponses  []stubListResponse
+		wantErr        error
 		wantTerminated bool
 		wantEvents     string
 	}{
@@ -621,8 +632,29 @@ func TestTerminateIfDangling(t *testing.T) {
 			wantEvents:     "[set desired capacity terminate instance]",
 		},
 		{
-			name:       "responsive instance is left alone",
-			wantEvents: "[]",
+			name:          "instance with an active agent service is left alone",
+			listResponses: probeResult(ssmTypes.CommandInvocationStatusSuccess),
+			wantEvents:    "[]",
+		},
+		{
+			// SendCommand accepts commands for ConnectionLost instances and
+			// leaves them Pending; accepted is not the same as executed.
+			name:           "probe that never executes is terminated",
+			listResponses:  probeResult(ssmTypes.CommandInvocationStatusPending),
+			wantTerminated: true,
+			wantEvents:     "[set desired capacity terminate instance]",
+		},
+		{
+			name:           "probe reporting a stopped agent service is terminated",
+			listResponses:  probeResult(ssmTypes.CommandInvocationStatusFailed),
+			wantTerminated: true,
+			wantEvents:     "[set desired capacity terminate instance]",
+		},
+		{
+			name:          "polling failure leaves the instance alone and reports the error",
+			listResponses: []stubListResponse{{err: listErr}},
+			wantErr:       listErr,
+			wantEvents:    "[]",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -631,11 +663,12 @@ func TestTerminateIfDangling(t *testing.T) {
 				stubDescribeInstancesClient:  &stubDescribeInstancesClient{},
 				terminateInstancesTestClient: &terminateInstancesTestClient{events: &asg.events},
 			}
+			ssmClient := &stubSSMClient{sendErr: tc.sendErr, listResponses: tc.listResponses}
 			s := Scaler{autoscaling: asg}
 
-			terminated, err := s.terminateIfDangling(t.Context(), ec2Client, &stubSSMClient{sendErr: tc.sendErr}, "i-a", 0)
-			if err != nil {
-				t.Fatalf("terminateIfDangling() error = %v", err)
+			terminated, err := s.terminateIfDangling(t.Context(), ec2Client, ssmClient, "i-a", 0, time.Millisecond, time.Millisecond)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("terminateIfDangling() error = %v, want %v", err, tc.wantErr)
 			}
 			if terminated != tc.wantTerminated {
 				t.Errorf("terminated = %v, want %v", terminated, tc.wantTerminated)

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
 
@@ -518,6 +521,61 @@ type terminateInstancesTestClient struct {
 func (c *terminateInstancesTestClient) TerminateInstances(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
 	*c.events = append(*c.events, "terminate instance")
 	return &ec2.TerminateInstancesOutput{}, nil
+}
+
+func describeOutput(instances ...ec2Types.Instance) *ec2.DescribeInstancesOutput {
+	return &ec2.DescribeInstancesOutput{Reservations: []ec2Types.Reservation{{Instances: instances}}}
+}
+
+func TestOldestInstances(t *testing.T) {
+	t0 := time.Date(2026, 9, 2, 8, 0, 0, 0, time.UTC)
+	instance := func(id string, launched time.Time) ec2Types.Instance {
+		return ec2Types.Instance{InstanceId: aws.String(id), LaunchTime: aws.Time(launched)}
+	}
+
+	for _, tc := range []struct {
+		name string
+		out  *ec2.DescribeInstancesOutput
+		n    int64
+		want []string
+	}{
+		{
+			name: "oldest first regardless of describe order",
+			out:  describeOutput(instance("i-c", t0.Add(2*time.Minute)), instance("i-a", t0), instance("i-b", t0.Add(time.Minute))),
+			n:    2,
+			want: []string{"i-a", "i-b"},
+		},
+		{
+			name: "launch time ties break on instance ID",
+			out:  describeOutput(instance("i-b", t0), instance("i-c", t0), instance("i-a", t0)),
+			n:    2,
+			want: []string{"i-a", "i-b"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &stubDescribeInstancesClient{responses: []stubDescribeResponse{{out: tc.out}}}
+			got, err := oldestInstances(t.Context(), client, []string{"i-a", "i-b", "i-c"}, tc.n, "asg-1")
+			if err != nil {
+				t.Fatalf("oldestInstances() error = %v", err)
+			}
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("oldestInstances() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOldestInstancesFailsClosedOnDescribeError(t *testing.T) {
+	describeErr := errors.New("throttled")
+	client := &stubDescribeInstancesClient{responses: []stubDescribeResponse{{err: describeErr}}}
+
+	got, err := oldestInstances(t.Context(), client, []string{"i-a", "i-b"}, 1, "asg-1")
+	if !errors.Is(err, describeErr) {
+		t.Fatalf("oldestInstances() error = %v, want %v", err, describeErr)
+	}
+	if len(got) != 0 {
+		t.Errorf("oldestInstances() = %v, want no candidates", got)
+	}
 }
 
 func TestDirectlyTerminateInstanceLowersDesiredCapacityFirst(t *testing.T) {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -457,6 +457,7 @@ type asgTestDriver struct {
 	maxSize                 int64 // If 0, defaults to 100
 	sigTermsSent            []string
 	sigTermsDispatched      int
+	useSigTermsDispatched   bool
 	sigTermErr              error
 	setDesiredCapacityCalls int
 	elasticCIMode           bool
@@ -501,7 +502,7 @@ func (d *asgTestDriver) SetDesiredCapacity(ctx context.Context, count int64) err
 func (d *asgTestDriver) SendSIGTERMToAgentsBatch(ctx context.Context, instanceIDs []string) (int, error) {
 	d.events = append(d.events, "send graceful stop")
 	d.sigTermsSent = append(d.sigTermsSent, instanceIDs...)
-	if d.sigTermErr != nil {
+	if d.useSigTermsDispatched || d.sigTermErr != nil {
 		return d.sigTermsDispatched, d.sigTermErr
 	}
 	return len(instanceIDs), d.err
@@ -516,11 +517,15 @@ func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {
 	testCases := []struct {
 		name                   string
 		dispatched             int
+		useDispatched          bool
 		dispatchErr            error
+		setDesiredErr          error
 		wantEvents             string
 		wantDesiredCapacity    int64
 		wantSetDesiredCapacity int
 		wantLastEvent          bool
+		wantErr                error
+		wantErrText            string
 	}{
 		{
 			name:                "successful Linux dispatch",
@@ -529,10 +534,20 @@ func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {
 			wantLastEvent:       true,
 		},
 		{
+			name:                "no online Linux instances",
+			useDispatched:       true,
+			wantEvents:          "[send graceful stop]",
+			wantDesiredCapacity: 3,
+			wantLastEvent:       true,
+			wantErr:             errNoReachableScaleInCandidates,
+		},
+		{
 			name:                "failed Linux dispatch",
 			dispatchErr:         errors.New("send command"),
 			wantEvents:          "[send graceful stop]",
 			wantDesiredCapacity: 3,
+			wantLastEvent:       true,
+			wantErrText:         "send command",
 		},
 		{
 			name:                "partially successful Linux dispatch",
@@ -550,14 +565,41 @@ func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {
 			wantSetDesiredCapacity: 1,
 			wantLastEvent:          true,
 		},
+		{
+			name:                   "Windows desired capacity update fails",
+			dispatchErr:            ErrWindowsGracefulScaleInNotSupported,
+			setDesiredErr:          errors.New("throttled"),
+			wantEvents:             "[send graceful stop set desired capacity]",
+			wantDesiredCapacity:    1,
+			wantSetDesiredCapacity: 1,
+			wantErrText:            "set desired capacity to 1 for windows instances: throttled",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			asg := &asgTestDriver{desiredCapacity: 3, sigTermsDispatched: tc.dispatched, sigTermErr: tc.dispatchErr}
+			asg := &asgTestDriver{
+				desiredCapacity:       3,
+				sigTermsDispatched:    tc.dispatched,
+				useSigTermsDispatched: tc.useDispatched,
+				sigTermErr:            tc.dispatchErr,
+				err:                   tc.setDesiredErr,
+			}
 			s := Scaler{autoscaling: asg}
 
-			s.gracefullyScaleIn(t.Context(), []string{"i-a", "i-b"}, 1)
+			err := s.gracefullyScaleIn(t.Context(), []string{"i-a", "i-b"}, 1)
+			switch {
+			case tc.wantErr != nil:
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("gracefullyScaleIn() error = %v, want %v", err, tc.wantErr)
+				}
+			case tc.wantErrText != "":
+				if err == nil || err.Error() != tc.wantErrText {
+					t.Fatalf("gracefullyScaleIn() error = %v, want %q", err, tc.wantErrText)
+				}
+			case err != nil:
+				t.Fatalf("gracefullyScaleIn() error = %v, want nil", err)
+			}
 
 			if got := fmt.Sprint(asg.events); got != tc.wantEvents {
 				t.Errorf("calls = %s, want %s", got, tc.wantEvents)

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
 
@@ -486,6 +487,7 @@ func (d *asgTestDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, er
 		Pending:      d.pendingCapacity,
 		DesiredCount: d.desiredCapacity,
 		ActualCount:  actualCount,
+		TotalCount:   d.desiredCapacity,
 		MinSize:      0,
 		MaxSize:      maxSize,
 		InstanceIDs:  instanceIDs,
@@ -511,6 +513,32 @@ func (d *asgTestDriver) SendSIGTERMToAgentsBatch(ctx context.Context, instanceID
 func (d *asgTestDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanceUptime time.Duration, maxDanglingInstancesToCheck int) error {
 	d.danglingInstancesFound++
 	return d.err
+}
+
+type terminateInstancesTestClient struct {
+	events *[]string
+}
+
+func (c *terminateInstancesTestClient) TerminateInstances(context.Context, *ec2.TerminateInstancesInput, ...func(*ec2.Options)) (*ec2.TerminateInstancesOutput, error) {
+	*c.events = append(*c.events, "terminate instance")
+	return &ec2.TerminateInstancesOutput{}, nil
+}
+
+func TestDirectlyTerminateInstanceLowersDesiredCapacityFirst(t *testing.T) {
+	asg := &asgTestDriver{desiredCapacity: 1}
+	ec2Client := &terminateInstancesTestClient{events: &asg.events}
+	s := Scaler{autoscaling: asg}
+
+	if err := s.directlyTerminateInstance(t.Context(), ec2Client, "i-a", 0); err != nil {
+		t.Fatalf("directlyTerminateInstance() error = %v", err)
+	}
+
+	if got, want := fmt.Sprint(asg.events), "[set desired capacity terminate instance]"; got != want {
+		t.Errorf("calls = %s, want %s", got, want)
+	}
+	if got, want := asg.desiredCapacity, int64(0); got != want {
+		t.Errorf("desired capacity = %d, want %d", got, want)
+	}
 }
 
 func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -457,8 +457,7 @@ type asgTestDriver struct {
 	pendingCapacity         int64
 	maxSize                 int64 // If 0, defaults to 100
 	sigTermsSent            []string
-	sigTermsDispatched      int
-	useSigTermsDispatched   bool
+	sigTermsAccepted        int
 	sigTermErr              error
 	setDesiredCapacityCalls int
 	elasticCIMode           bool
@@ -504,10 +503,7 @@ func (d *asgTestDriver) SetDesiredCapacity(ctx context.Context, count int64) err
 func (d *asgTestDriver) SendSIGTERMToAgentsBatch(ctx context.Context, instanceIDs []string) (int, error) {
 	d.events = append(d.events, "send graceful stop")
 	d.sigTermsSent = append(d.sigTermsSent, instanceIDs...)
-	if d.useSigTermsDispatched || d.sigTermErr != nil {
-		return d.sigTermsDispatched, d.sigTermErr
-	}
-	return len(instanceIDs), d.err
+	return d.sigTermsAccepted, d.sigTermErr
 }
 
 func (d *asgTestDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanceUptime time.Duration, maxDanglingInstancesToCheck int) error {
@@ -543,75 +539,70 @@ func TestDirectlyTerminateInstanceLowersDesiredCapacityFirst(t *testing.T) {
 
 func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {
 	testCases := []struct {
-		name                   string
-		dispatched             int
-		useDispatched          bool
-		dispatchErr            error
-		setDesiredErr          error
-		wantEvents             string
-		wantDesiredCapacity    int64
-		wantSetDesiredCapacity int
-		wantLastEvent          bool
-		wantErr                error
-		wantErrText            string
+		name                string
+		accepted            int
+		dispatchErr         error
+		setDesiredErr       error
+		wantEvents          string
+		wantDesiredCapacity int64
+		wantLastEvent       bool
+		wantErr             error
+		wantErrText         string
 	}{
 		{
 			name:                "successful Linux dispatch",
+			accepted:            2,
 			wantEvents:          "[send graceful stop]",
 			wantDesiredCapacity: 3,
 			wantLastEvent:       true,
 		},
 		{
 			name:                "no online Linux instances",
-			useDispatched:       true,
 			wantEvents:          "[send graceful stop]",
 			wantDesiredCapacity: 3,
 			wantLastEvent:       true,
 			wantErr:             errNoReachableScaleInCandidates,
 		},
 		{
-			name:                "failed Linux dispatch",
-			dispatchErr:         errors.New("send command"),
+			name:                "SSM API failure",
+			dispatchErr:         errors.New("describe SSM instance information: throttled"),
 			wantEvents:          "[send graceful stop]",
 			wantDesiredCapacity: 3,
 			wantLastEvent:       true,
-			wantErrText:         "send command",
+			wantErrText:         "describe SSM instance information: throttled",
 		},
 		{
 			name:                "partially successful Linux dispatch",
-			dispatched:          1,
+			accepted:            1,
 			dispatchErr:         errors.New("send command to later batch"),
 			wantEvents:          "[send graceful stop]",
 			wantDesiredCapacity: 3,
 			wantLastEvent:       true,
 		},
 		{
-			name:                   "Windows dispatch skipped",
-			dispatchErr:            ErrWindowsGracefulScaleInNotSupported,
-			wantEvents:             "[send graceful stop set desired capacity]",
-			wantDesiredCapacity:    1,
-			wantSetDesiredCapacity: 1,
-			wantLastEvent:          true,
+			name:                "Windows dispatch skipped",
+			dispatchErr:         ErrWindowsGracefulScaleInNotSupported,
+			wantEvents:          "[send graceful stop set desired capacity]",
+			wantDesiredCapacity: 1,
+			wantLastEvent:       true,
 		},
 		{
-			name:                   "Windows desired capacity update fails",
-			dispatchErr:            ErrWindowsGracefulScaleInNotSupported,
-			setDesiredErr:          errors.New("throttled"),
-			wantEvents:             "[send graceful stop set desired capacity]",
-			wantDesiredCapacity:    1,
-			wantSetDesiredCapacity: 1,
-			wantErrText:            "set desired capacity to 1 for windows instances: throttled",
+			name:                "Windows desired capacity update fails",
+			dispatchErr:         ErrWindowsGracefulScaleInNotSupported,
+			setDesiredErr:       errors.New("throttled"),
+			wantEvents:          "[send graceful stop set desired capacity]",
+			wantDesiredCapacity: 1,
+			wantErrText:         "set desired capacity to 1 for windows instances: throttled",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			asg := &asgTestDriver{
-				desiredCapacity:       3,
-				sigTermsDispatched:    tc.dispatched,
-				useSigTermsDispatched: tc.useDispatched,
-				sigTermErr:            tc.dispatchErr,
-				err:                   tc.setDesiredErr,
+				desiredCapacity:  3,
+				sigTermsAccepted: tc.accepted,
+				sigTermErr:       tc.dispatchErr,
+				err:              tc.setDesiredErr,
 			}
 			s := Scaler{autoscaling: asg}
 
@@ -632,14 +623,8 @@ func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {
 			if got := fmt.Sprint(asg.events); got != tc.wantEvents {
 				t.Errorf("calls = %s, want %s", got, tc.wantEvents)
 			}
-			if got, want := fmt.Sprint(asg.sigTermsSent), "[i-a i-b]"; got != want {
-				t.Errorf("graceful-stop targets = %s, want %s", got, want)
-			}
 			if got := asg.desiredCapacity; got != tc.wantDesiredCapacity {
 				t.Errorf("desired capacity = %d, want %d", got, tc.wantDesiredCapacity)
-			}
-			if got := asg.setDesiredCapacityCalls; got != tc.wantSetDesiredCapacity {
-				t.Errorf("SetDesiredCapacity calls = %d, want %d", got, tc.wantSetDesiredCapacity)
 			}
 			if got := !s.scaleInParams.LastEvent.IsZero(); got != tc.wantLastEvent {
 				t.Errorf("LastEvent recorded = %t, want %t", got, tc.wantLastEvent)

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -9,10 +9,32 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/buildkite/buildkite-agent-scaler/buildkite"
 )
+
+func TestNewScalerConfiguresScalingActivityLookup(t *testing.T) {
+	s, err := NewScaler(nil, aws.Config{}, Params{
+		ASGActivityTimeout:                3 * time.Second,
+		MaxDescribeScalingActivitiesPages: 7,
+	})
+	if err != nil {
+		t.Fatalf("NewScaler() error = %v", err)
+	}
+	driver, ok := s.autoscaling.(*ASGDriver)
+	if !ok {
+		t.Fatalf("autoscaling driver type = %T, want *ASGDriver", s.autoscaling)
+	}
+	if got := driver.scalingActivitiesTimeout; got != 3*time.Second {
+		t.Errorf("scaling activities timeout = %s, want %s", got, 3*time.Second)
+	}
+	if got := driver.MaxDescribeScalingActivitiesPages; got != 7 {
+		t.Errorf("maximum scaling activity pages = %d, want 7", got)
+	}
+}
 
 func TestScalingOutWithoutError(t *testing.T) {
 	for _, tc := range []struct {
@@ -827,6 +849,89 @@ func TestScalerRunWaitsToScaleInWhileInstancesArePending(t *testing.T) {
 	}
 	if asg.desiredCapacity != 5 {
 		t.Errorf("desired capacity = %d, want 5", asg.desiredCapacity)
+	}
+}
+
+func TestScaleInFailsClosedWhenActivityLookupFails(t *testing.T) {
+	wantErr := errors.New("describe activities")
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{{err: wantErr}},
+	}
+	driver := &ASGDriver{
+		Name:                              "agents",
+		MaxDescribeScalingActivitiesPages: -1,
+		scalingActivitiesSvc:              client,
+		scalingActivitiesTimeout:          time.Second,
+	}
+	s := Scaler{
+		autoscaling:   driver,
+		elasticCIMode: true,
+		scaleInParams: ScaleParams{
+			CooldownPeriod: time.Hour,
+		},
+	}
+
+	err := s.scaleIn(t.Context(), 1, AutoscaleGroupDetails{DesiredCount: 2})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("scaleIn() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestScaleInActivityLookupUsesCallerContext(t *testing.T) {
+	client := &stubScalingActivitiesClient{
+		describe: func(ctx context.Context, _ *autoscaling.DescribeScalingActivitiesInput) (*autoscaling.DescribeScalingActivitiesOutput, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	driver := &ASGDriver{
+		MaxDescribeScalingActivitiesPages: -1,
+		scalingActivitiesSvc:              client,
+		scalingActivitiesTimeout:          time.Hour,
+	}
+	s := Scaler{
+		autoscaling:   driver,
+		elasticCIMode: true,
+		scaleInParams: ScaleParams{
+			CooldownPeriod: time.Hour,
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := s.scaleIn(ctx, 1, AutoscaleGroupDetails{DesiredCount: 2})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("scaleIn() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestScaleInHonorsRecoveredActivity(t *testing.T) {
+	client := &stubScalingActivitiesClient{
+		responses: []stubScalingActivitiesResponse{{
+			output: &autoscaling.DescribeScalingActivitiesOutput{
+				Activities: []types.Activity{{
+					Cause:      aws.String("At 2026-08-26T16:14:36Z instance i-017bacd33066f0408 was taken out of service in response to a user request, shrinking the capacity from 2 to 1."),
+					StartTime:  aws.Time(time.Now().Add(-time.Minute)),
+					StatusCode: types.ScalingActivityStatusCodeSuccessful,
+				}},
+			},
+		}},
+	}
+	driver := &ASGDriver{
+		MaxDescribeScalingActivitiesPages: -1,
+		scalingActivitiesSvc:              client,
+		scalingActivitiesTimeout:          time.Second,
+	}
+	s := Scaler{
+		autoscaling:   driver,
+		elasticCIMode: true,
+		scaleInParams: ScaleParams{
+			CooldownPeriod: time.Hour,
+		},
+	}
+
+	if err := s.scaleIn(t.Context(), 1, AutoscaleGroupDetails{DesiredCount: 2}); err != nil {
+		t.Fatalf("scaleIn() error = %v", err)
 	}
 }
 

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -2,6 +2,7 @@ package scaler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -455,9 +456,12 @@ type asgTestDriver struct {
 	pendingCapacity         int64
 	maxSize                 int64 // If 0, defaults to 100
 	sigTermsSent            []string
+	sigTermsDispatched      int
+	sigTermErr              error
 	setDesiredCapacityCalls int
 	elasticCIMode           bool
 	danglingInstancesFound  int
+	events                  []string
 }
 
 func (d *asgTestDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, error) {
@@ -490,20 +494,88 @@ func (d *asgTestDriver) Describe(ctx context.Context) (AutoscaleGroupDetails, er
 func (d *asgTestDriver) SetDesiredCapacity(ctx context.Context, count int64) error {
 	d.setDesiredCapacityCalls++
 	d.desiredCapacity = count
+	d.events = append(d.events, "set desired capacity")
 	return d.err
 }
 
-func (d *asgTestDriver) SendSIGTERMToAgents(ctx context.Context, instanceID string) error {
-	if d.sigTermsSent == nil {
-		d.sigTermsSent = []string{}
+func (d *asgTestDriver) SendSIGTERMToAgentsBatch(ctx context.Context, instanceIDs []string) (int, error) {
+	d.events = append(d.events, "send graceful stop")
+	d.sigTermsSent = append(d.sigTermsSent, instanceIDs...)
+	if d.sigTermErr != nil {
+		return d.sigTermsDispatched, d.sigTermErr
 	}
-	d.sigTermsSent = append(d.sigTermsSent, instanceID)
-	return d.err
+	return len(instanceIDs), d.err
 }
 
 func (d *asgTestDriver) CleanupDanglingInstances(ctx context.Context, minimumInstanceUptime time.Duration, maxDanglingInstancesToCheck int) error {
 	d.danglingInstancesFound++
 	return d.err
+}
+
+func TestGracefullyScaleInLetsLinuxAgentsDecrementCapacity(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		dispatched             int
+		dispatchErr            error
+		wantEvents             string
+		wantDesiredCapacity    int64
+		wantSetDesiredCapacity int
+		wantLastEvent          bool
+	}{
+		{
+			name:                "successful Linux dispatch",
+			wantEvents:          "[send graceful stop]",
+			wantDesiredCapacity: 3,
+			wantLastEvent:       true,
+		},
+		{
+			name:                "failed Linux dispatch",
+			dispatchErr:         errors.New("send command"),
+			wantEvents:          "[send graceful stop]",
+			wantDesiredCapacity: 3,
+		},
+		{
+			name:                "partially successful Linux dispatch",
+			dispatched:          1,
+			dispatchErr:         errors.New("send command to later batch"),
+			wantEvents:          "[send graceful stop]",
+			wantDesiredCapacity: 3,
+			wantLastEvent:       true,
+		},
+		{
+			name:                   "Windows dispatch skipped",
+			dispatchErr:            ErrWindowsGracefulScaleInNotSupported,
+			wantEvents:             "[send graceful stop set desired capacity]",
+			wantDesiredCapacity:    1,
+			wantSetDesiredCapacity: 1,
+			wantLastEvent:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			asg := &asgTestDriver{desiredCapacity: 3, sigTermsDispatched: tc.dispatched, sigTermErr: tc.dispatchErr}
+			s := Scaler{autoscaling: asg}
+
+			s.gracefullyScaleIn(t.Context(), []string{"i-a", "i-b"}, 1)
+
+			if got := fmt.Sprint(asg.events); got != tc.wantEvents {
+				t.Errorf("calls = %s, want %s", got, tc.wantEvents)
+			}
+			if got, want := fmt.Sprint(asg.sigTermsSent), "[i-a i-b]"; got != want {
+				t.Errorf("graceful-stop targets = %s, want %s", got, want)
+			}
+			if got := asg.desiredCapacity; got != tc.wantDesiredCapacity {
+				t.Errorf("desired capacity = %d, want %d", got, tc.wantDesiredCapacity)
+			}
+			if got := asg.setDesiredCapacityCalls; got != tc.wantSetDesiredCapacity {
+				t.Errorf("SetDesiredCapacity calls = %d, want %d", got, tc.wantSetDesiredCapacity)
+			}
+			if got := !s.scaleInParams.LastEvent.IsZero(); got != tc.wantLastEvent {
+				t.Errorf("LastEvent recorded = %t, want %t", got, tc.wantLastEvent)
+			}
+		})
+	}
 }
 
 // TestScaleInWhileASGConverging pins the early return in Run that suppresses

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -616,14 +616,17 @@ func TestTerminateIfDangling(t *testing.T) {
 		}}}
 	}
 	listErr := errors.New("ListCommandInvocations throttled")
+	metricsErr := errors.New("buildkite metrics unavailable")
 
 	for _, tc := range []struct {
-		name           string
-		sendErr        error
-		listResponses  []stubListResponse
-		wantErr        error
-		wantTerminated bool
-		wantEvents     string
+		name            string
+		sendErr         error
+		listResponses   []stubListResponse
+		connectedAgents int64
+		metricsErr      error
+		wantErr         error
+		wantTerminated  bool
+		wantEvents      string
 	}{
 		{
 			name:           "unreachable instance is terminated after lowering capacity",
@@ -639,10 +642,18 @@ func TestTerminateIfDangling(t *testing.T) {
 		{
 			// SendCommand accepts commands for ConnectionLost instances and
 			// leaves them Pending; accepted is not the same as executed.
-			name:           "probe that never executes is terminated",
+			name:           "probe that never executes is terminated when no agents are connected",
 			listResponses:  probeResult(ssmTypes.CommandInvocationStatusPending),
 			wantTerminated: true,
 			wantEvents:     "[set desired capacity terminate instance]",
+		},
+		{
+			// A broken SSM agent says nothing about buildkite-agent, which may
+			// have picked up a job while we waited on the probe.
+			name:            "probe that never executes is left alone while an agent is connected",
+			listResponses:   probeResult(ssmTypes.CommandInvocationStatusPending),
+			connectedAgents: 1,
+			wantEvents:      "[]",
 		},
 		{
 			name:           "probe reporting a stopped agent service is terminated",
@@ -656,6 +667,13 @@ func TestTerminateIfDangling(t *testing.T) {
 			wantErr:       listErr,
 			wantEvents:    "[]",
 		},
+		{
+			name:          "metrics failure leaves the instance alone and reports the error",
+			listResponses: probeResult(ssmTypes.CommandInvocationStatusPending),
+			metricsErr:    metricsErr,
+			wantErr:       metricsErr,
+			wantEvents:    "[]",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			asg := &asgTestDriver{desiredCapacity: 1}
@@ -664,7 +682,13 @@ func TestTerminateIfDangling(t *testing.T) {
 				terminateInstancesTestClient: &terminateInstancesTestClient{events: &asg.events},
 			}
 			ssmClient := &stubSSMClient{sendErr: tc.sendErr, listResponses: tc.listResponses}
-			s := Scaler{autoscaling: asg}
+			s := Scaler{
+				autoscaling: asg,
+				bk: &buildkiteTestDriver{
+					metrics: buildkite.AgentMetrics{TotalAgents: tc.connectedAgents},
+					err:     tc.metricsErr,
+				},
+			}
 
 			terminated, err := s.terminateIfDangling(t.Context(), ec2Client, ssmClient, "i-a", 0, time.Millisecond, time.Millisecond)
 			if !errors.Is(err, tc.wantErr) {

--- a/scaler/scaler_test.go
+++ b/scaler/scaler_test.go
@@ -545,6 +545,13 @@ func (c *terminateInstancesTestClient) TerminateInstances(context.Context, *ec2.
 	return &ec2.TerminateInstancesOutput{}, nil
 }
 
+// dangleProbeTestClient combines the describe and terminate stubs so one value
+// satisfies dangleProbeEC2API.
+type dangleProbeTestClient struct {
+	*stubDescribeInstancesClient
+	*terminateInstancesTestClient
+}
+
 func describeOutput(instances ...ec2Types.Instance) *ec2.DescribeInstancesOutput {
 	return &ec2.DescribeInstancesOutput{Reservations: []ec2Types.Reservation{{Instances: instances}}}
 }
@@ -597,6 +604,46 @@ func TestOldestInstancesFailsClosedOnDescribeError(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("oldestInstances() = %v, want no candidates", got)
+	}
+}
+
+func TestTerminateIfDangling(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		sendErr        error
+		wantTerminated bool
+		wantEvents     string
+	}{
+		{
+			name:           "unreachable instance is terminated after lowering capacity",
+			sendErr:        errors.New("InvalidInstanceId"),
+			wantTerminated: true,
+			wantEvents:     "[set desired capacity terminate instance]",
+		},
+		{
+			name:       "responsive instance is left alone",
+			wantEvents: "[]",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			asg := &asgTestDriver{desiredCapacity: 1}
+			ec2Client := dangleProbeTestClient{
+				stubDescribeInstancesClient:  &stubDescribeInstancesClient{},
+				terminateInstancesTestClient: &terminateInstancesTestClient{events: &asg.events},
+			}
+			s := Scaler{autoscaling: asg}
+
+			terminated, err := s.terminateIfDangling(t.Context(), ec2Client, &stubSSMClient{sendErr: tc.sendErr}, "i-a", 0)
+			if err != nil {
+				t.Fatalf("terminateIfDangling() error = %v", err)
+			}
+			if terminated != tc.wantTerminated {
+				t.Errorf("terminated = %v, want %v", terminated, tc.wantTerminated)
+			}
+			if got := fmt.Sprint(asg.events); got != tc.wantEvents {
+				t.Errorf("calls = %s, want %s", got, tc.wantEvents)
+			}
+		})
 	}
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -133,7 +133,7 @@ Parameters:
 
   MaxDescribeScalingActivitiesPages:
     Type: Number
-    Description: The number of pages to retrive for DescribeScalingActivity. Negative numbers mean unlimited.
+    Description: The maximum number of pages to retrieve for DescribeScalingActivities. Non-positive numbers mean unlimited.
     Default: "-1"
 
   MinPollInterval:


### PR DESCRIPTION
Stacked on #352.

Fixes two things on the "last instance can't be reached" path in scale-in.

First, when we did terminate the instance directly, `scaleIn` still returned the graceful scale-in error, so Lambda logged a failed run and the standalone command `log.Fatal`ed after actually doing the right thing. It now returns nil.

Second, the agent probe only checked that `SendCommand` was accepted. On a `ConnectionLost` instance the command just sits in `Pending`, so we kept treating the instance as alive and desired stayed stuck at 1. We now wait for the probe to finish. Only `Success` means the agent is up. Anything else just tells us the SSM agent didn't run it, so before hard-killing we call Buildkite whether any agents are still connected on the queue and back off if there are. That covers the agent grabbing a job while we waited. If the metrics call fails we leave the instance alone and return the error.

Tests cover the success return, a probe that never runs, an inconclusive probe with an agent still connected, and a metrics failure.